### PR TITLE
Fix railway loading date mapping

### DIFF
--- a/models/container_event.py
+++ b/models/container_event.py
@@ -36,6 +36,8 @@ class TrackingResult:
     has_duplicates: bool = False
     processing_time: str = ""
     error_message: str | None = None
+    # Специальная дата для операции "Отправление вагона со станции"
+    earliest_railway_loading_date: str | None = None
     
     def __post_init__(self):
         self.processing_time = datetime.now().isoformat()

--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -4,6 +4,7 @@
 """
 
 import asyncio
+from datetime import datetime
 from typing import List, Dict, Set, AsyncGenerator, Optional, Union, Tuple
 import aiohttp
 from dataclasses import dataclass
@@ -22,7 +23,7 @@ from utils.db.firebird_manager import (
     create_firebird_entity_manager
 )
 
-from models.container_event import TrackingResult
+from models.container_event import TrackingResult, ContainerEvent
 from models.processing_stats import ProcessingStats
 from utils.logging import get_logger
 
@@ -322,6 +323,13 @@ class ContainerTrackingEngine:
                 order_data, order_id, container.container_number
             )
             container_events = self.event_processor.extract_container_events(container_data)
+
+            # ищем самую раннюю дату операции "Отправление вагона со станции"
+            all_events = order_events + container_events
+            result.earliest_railway_loading_date = self._find_earliest_event_date(
+                all_events,
+                "Отправление вагона со станции",
+            )
             
             final_event, has_duplicates, source = self.event_processor.merge_and_deduplicate(
                 order_events, container_events
@@ -351,21 +359,29 @@ class ContainerTrackingEngine:
         written_count = 0
         for container_info, tracking_result in container_results:
             try:
-                mapping = self.firebird_manager.operation_matcher.find_best_mapping(
-                    tracking_result.last_event.operation    # type: ignore
-                ) if tracking_result.last_event else None
+                mapping = (
+                    self.firebird_manager.operation_matcher.find_best_mapping(
+                        tracking_result.last_event.operation
+                    )
+                    if tracking_result.last_event
+                    else None
+                )
 
                 if (
                     mapping
                     and mapping.entity_column
                     == self.firebird_manager.entity_config.date_railway_loading
-                    and container_info.current_dates.get(mapping.entity_column)
                 ):
-                    self.logger.debug(
-                        f"⏭️ {container_info.container_number}: "
-                        f"{mapping.entity_column} уже заполнено"
-                    )
-                    continue
+                    existing = container_info.current_dates.get(mapping.entity_column)
+                    expected = tracking_result.earliest_railway_loading_date
+                    if existing and expected:
+                        existing_dt = self.firebird_manager.transformer.transform_value(existing, "DATE")
+                        expected_dt = self.firebird_manager.transformer.transform_value(expected, "DATE")
+                        if existing_dt == expected_dt:
+                            self.logger.debug(
+                                f"⏭️ {container_info.container_number}: {mapping.entity_column} уже верная"
+                            )
+                            continue
                 # КЛЮЧЕВОЕ: Используем container_info.id для обновления записи
                 success = await self.firebird_manager.update_container_from_tracking(
                     container_info.id,  # ID записи в entity таблице
@@ -373,11 +389,18 @@ class ContainerTrackingEngine:
                 )
                 
                 if success and mapping:
-                    container_info.current_dates[mapping.entity_column] = (
-                        tracking_result.last_event.date
-                        if tracking_result.last_event
-                        else container_info.current_dates.get(mapping.entity_column)
-                    )
+                    if (
+                        mapping.entity_column
+                        == self.firebird_manager.entity_config.date_railway_loading
+                        and tracking_result.earliest_railway_loading_date
+                    ):
+                        container_info.current_dates[mapping.entity_column] = tracking_result.earliest_railway_loading_date
+                    else:
+                        container_info.current_dates[mapping.entity_column] = (
+                            tracking_result.last_event.date
+                            if tracking_result.last_event
+                            else container_info.current_dates.get(mapping.entity_column)
+                        )
 
                 if success:
                     written_count += 1
@@ -416,6 +439,24 @@ class ContainerTrackingEngine:
             return cached_data == current_data
         except:
             return False
+
+    def _find_earliest_event_date(
+        self,
+        events: List[ContainerEvent],
+        operation_name: str,
+    ) -> Optional[str]:
+        """Найти самую раннюю дату события по названию операции"""
+        earliest: Optional[datetime] = None
+
+        for ev in events:
+            if not ev.operation or not ev.date:
+                continue
+            if operation_name.lower() in ev.operation.lower():
+                dt = self.firebird_manager.transformer.transform_value(ev.date, "TIMESTAMP")
+                if dt and (earliest is None or dt < earliest):
+                    earliest = dt
+
+        return earliest.isoformat() if earliest else None
     
     async def _log_final_statistics(self) -> None:
         """Вывод финальной статистики workflow"""

--- a/tests/db/firebird_manager_test.py
+++ b/tests/db/firebird_manager_test.py
@@ -413,6 +413,46 @@ class TestFirebirdStatisticsCollector:
         assert stats.stats['operation_times'][0] == 100.0
         assert stats.stats['operation_times'][-1] == 1099.0
 
+    def test_prepare_update_data_uses_earliest_date(self, entity_config):
+        """Проверка, что для DATE_RAILWAY_LOADING берется самая ранняя дата"""
+        if not FIREBIRD_AVAILABLE:
+            pytest.skip("Firebird driver не установлен")
+
+        manager = FirebirdEntityManager({'host':'h','database':'db','user':'u','password':'p'}, entity_config)
+        mapping = entity_config.date_mappings[entity_config.date_railway_loading]
+        result = TrackingResult(container_number="TEST")
+        result.last_event = ContainerEvent(operation="Отправление вагона со станции", date="2024-01-20")
+        result.earliest_railway_loading_date = "2024-01-15"
+
+        update = manager._prepare_update_data(result, mapping)
+
+        assert mapping.entity_column in update
+        assert str(update[mapping.entity_column]).startswith("2024-01-15")
+
+    @pytest.mark.asyncio
+    @patch('firebird_manager.fdb')
+    async def test_write_results_skip_when_date_matches(self, mock_fdb, entity_config):
+        if not FIREBIRD_AVAILABLE:
+            pytest.skip("Firebird driver не установлен")
+        """Engine не обновляет дату если она уже соответствует"""
+        manager = FirebirdEntityManager({'host':'h','database':'db','user':'u','password':'p'}, entity_config)
+        config = Config()
+        engine = ContainerTrackingEngine(config, MagicMock(), manager)
+
+        container = ContainerInfo(
+            id=1,
+            container_number="TEST",
+            current_dates={entity_config.date_railway_loading: "2024-01-15"},
+        )
+
+        result = TrackingResult(container_number="TEST")
+        result.last_event = ContainerEvent(operation="Отправление вагона со станции", date="2024-01-20")
+        result.earliest_railway_loading_date = "2024-01-15"
+
+        with patch.object(manager, 'update_container_from_tracking', new=AsyncMock()) as mock_update:
+            await engine._write_results_to_firebird([(container, result)])
+            mock_update.assert_not_called()
+
 
 # =============================================================================
 # INTEGRATION TESTS - ИСПРАВЛЕННЫЕ И ДОПОЛНЕННЫЕ

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -996,7 +996,12 @@ class FirebirdEntityManager:
         update_data = {}
         
         # Получаем значение по полю маппинга
-        if date_mapping.fesco_field == "date":
+        if (
+            date_mapping.entity_column == self.entity_config.date_railway_loading
+            and getattr(tracking_result, "earliest_railway_loading_date", None)
+        ):
+            raw_value = tracking_result.earliest_railway_loading_date
+        elif date_mapping.fesco_field == "date":
             raw_value = getattr(tracking_result.last_event, "date", None)
         elif date_mapping.fesco_field == "remainingDistance":
             raw_value = getattr(tracking_result.last_event, "remainingDistance", None)


### PR DESCRIPTION
## Summary
- store earliest railway loading date on TrackingResult
- derive earliest dispatch date from all events
- skip Firebird writes if date already matches
- use earliest dispatch date during Firebird updates
- test handling of earliest railway loading dates

## Testing
- `PYTHONPATH=. pytest tests/db/firebird_manager_test.py::TestFirebirdStatisticsCollector::test_prepare_update_data_uses_earliest_date -q`
- `PYTHONPATH=. pytest tests/db/firebird_manager_test.py -q` *(fails: ModuleNotFoundError: No module named 'firebird_manager')*

------
https://chatgpt.com/codex/tasks/task_e_6877447f9298832a89e1cf3339e32e08