### PR TITLE
Fix redis close deprecation warning

### DIFF
--- a/cache/redis_cache.py
+++ b/cache/redis_cache.py
@@ -126,7 +126,10 @@ class RedisCache(CacheBackend):
         """Закрыть соединение с Redis"""
         if self.client:
             try:
-                await self.client.close()
+                if hasattr(self.client, "aclose"):
+                    await self.client.aclose()
+                else:
+                    await self.client.close()
                 logging.info("🔄 Redis connection closed")
             except Exception as e:
                 logging.error(f"Redis close error: {e}")

--- a/utils/redis_backend/redis_manager.py
+++ b/utils/redis_backend/redis_manager.py
@@ -123,7 +123,10 @@ class RedisManager:
     async def close(self) -> None:
         """Закрыть все соединения"""
         if self._client:
-            await self._client.close()
+            if hasattr(self._client, "aclose"):
+                await self._client.aclose()
+            else:
+                await self._client.close()
             self.logger.info("Redis connections closed")
             self._client = None
 


### PR DESCRIPTION
## Summary
- call the modern aclose() method when shutting down redis clients
- fall back to close() for older redis versions

## Testing
- `PYTHONPATH=$PWD pytest --import-mode=importlib -q`

------
https://chatgpt.com/codex/tasks/task_e_687f357faeb4832a8312772c799ef6dd