### PR TITLE
feat: support railway contractors and DATE_IN override

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,6 +87,7 @@ class FirebirdDatabaseConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # === КОЛОНКИ ДАТ ===
     date_eta: str = "DATE_ETA"
@@ -99,6 +100,7 @@ class FirebirdDatabaseConfig:
     # === НАСТРОЙКИ ОБРАБОТКИ ===
     excluded_status_ids: List[int] = field(default_factory=lambda: [8, 9, 24])  # закрыто, доставлено, отменено
     target_line_ids: List[int] = field(default_factory=lambda: [451, 751])  # Если пусто - все линии
+    target_carrier_ids: List[int] = field(default_factory=list)
     batch_size: int = 100
     max_connections: int = 10
     
@@ -116,6 +118,13 @@ class FirebirdDatabaseConfig:
         else:
             # Одинарное значение (int/str и др.)
             self.target_line_ids = [int(self.target_line_ids)]
+
+        if isinstance(self.target_carrier_ids, list):
+            self.target_carrier_ids = [int(x) for x in self.target_carrier_ids]
+        elif self.target_carrier_ids is None:
+            self.target_carrier_ids = []
+        else:
+            self.target_carrier_ids = [int(self.target_carrier_ids)]
 
         """Валидация Firebird конфигурации"""
         if not self.host:

--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -76,7 +76,8 @@ class ContainerTrackingEngine:
     async def run_full_workflow(
         self,
         batch_size: int = 100,
-        target_line_ids: Optional[Set[int]] = None
+        target_line_ids: Optional[Set[int]] = None,
+        target_carrier_ids: Optional[Set[int]] = None
     ) -> EngineStats:
         """
         Запуск полного workflow обработки
@@ -84,12 +85,15 @@ class ContainerTrackingEngine:
         Args:
             batch_size: Размер батча для обработки контейнеров
             target_line_ids: ID линий для фильтрации (None = все линии)
+            target_carrier_ids: ID ЖД перевозчиков для фильтрации
             
         Returns:
             Статистика выполнения
         """
         if target_line_ids is None:
             target_line_ids = set(self.config.database.target_line_ids)
+        if target_carrier_ids is None:
+            target_carrier_ids = set(getattr(self.config.database, 'target_carrier_ids', []))
 
         self.logger.info("🚀 Запуск полного workflow трекинга")
         self.logger.info("="*60)
@@ -110,7 +114,8 @@ class ContainerTrackingEngine:
                 # ИЗМЕНЕНО: Читаем контейнеры напрямую из Firebird
                 async for batch in self.firebird_manager.get_containers_for_processing(
                     batch_size=batch_size,
-                    target_line_ids=target_line_ids
+                    target_line_ids=target_line_ids,
+                    target_carrier_ids=target_carrier_ids
                 ):
                     await self._process_container_batch(session, batch)
                     self.engine_stats.firebird_read_batches += 1
@@ -404,7 +409,23 @@ class ContainerTrackingEngine:
                             stored_value, mapping.column_datatype
                         )
 
+                        override_do1 = False
                         if (
+                            mapping.entity_column == self.firebird_manager.entity_config.date_in
+                            and tracking_result.last_event
+                            and tracking_result.last_event.operation in (
+                                "Регистрация ДО1", "DO1 registration"
+                            )
+                            and not container_info.processing_flags.get("date_in_do1_overridden")
+                            and container_info.processing_flags.get("date_in_source")
+                                in (None, "Прием с моря", "Discharged from vessel")
+                        ):
+                            override_do1 = True
+                            self.logger.debug(
+                                f"♻️ {container_info.container_number}: overriding DATE_IN by DO1"
+                            )
+
+                        if not override_do1 and (
                             parsed_new is not None
                             and parsed_stored is not None
                             and parsed_new >= parsed_stored
@@ -430,6 +451,17 @@ class ContainerTrackingEngine:
                         if tracking_result.last_event
                         else container_info.current_dates.get(mapping.entity_column)
                     )
+                    if (
+                        mapping.entity_column == self.firebird_manager.entity_config.date_in
+                        and tracking_result.last_event
+                    ):
+                        container_info.processing_flags["date_in_source"] = (
+                            tracking_result.last_event.operation
+                        )
+                        if tracking_result.last_event.operation in (
+                            "Регистрация ДО1", "DO1 registration"
+                        ):
+                            container_info.processing_flags["date_in_do1_overridden"] = True
 
                 if success and new_remaining is not None:
                     container_info.remaining_distance = new_remaining

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -51,7 +51,7 @@ class DummyFirebirdManager:
     async def test_connection(self):
         return True
 
-    async def get_containers_for_processing(self, batch_size=100, target_line_ids=None):
+    async def get_containers_for_processing(self, batch_size=100, target_line_ids=None, target_carrier_ids=None):
         yield self.containers
 
     async def update_container_from_tracking(self, container_id, tracking_result):
@@ -161,3 +161,145 @@ async def test_skip_container_with_no_order():
     assert stats.containers_loaded == 1
     assert stats.orders_processed == 0
     assert await engine.binding_manager.is_container_no_order("CONT1") is True
+
+
+@pytest.mark.asyncio
+async def test_date_in_override_do1():
+    container = ContainerInfo(
+        id=5,
+        container_number="CONT5",
+        line_id=1,
+        current_dates={"DATE_IN": "2025-08-01 10:00"},
+        processing_flags={"date_in_source": "Прием с моря"},
+    )
+
+    class Do1FirebirdManager(DummyFirebirdManager):
+        def __init__(self):
+            super().__init__([container])
+            mapping = MagicMock()
+            mapping.entity_column = "DATE_IN"
+            mapping.column_datatype = "TIMESTAMP"
+            self.operation_matcher.find_best_mapping.return_value = mapping
+            self.entity_config.date_in = "DATE_IN"
+            self.entity_config.remaining_distance = "TRACING_DAYS"
+            self.transformer = MagicMock(transform_value=lambda v, t: v)
+
+        async def update_container_from_tracking(self, container_id, tracking_result):
+            self.updated.append(container_id)
+            return True
+
+    firebird = Do1FirebirdManager()
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    tr = TrackingResult(container_number="CONT5")
+    tr.last_event = ContainerEvent(
+        date="2025-08-02 12:00",
+        operation="Регистрация ДО1",
+        location="Test",
+    )
+
+    await engine._write_results_to_firebird([(container, tr)])
+
+    assert firebird.updated == [5]
+    assert container.current_dates["DATE_IN"] == "2025-08-02 12:00"
+
+
+@pytest.mark.asyncio
+async def test_date_in_no_override_after_do1():
+    container = ContainerInfo(
+        id=6,
+        container_number="CONT6",
+        line_id=1,
+        current_dates={"DATE_IN": "2025-08-01 10:00"},
+        processing_flags={"date_in_source": "Прием с моря"},
+    )
+
+    class Do1FirebirdManager(DummyFirebirdManager):
+        def __init__(self):
+            super().__init__([container])
+            mapping = MagicMock()
+            mapping.entity_column = "DATE_IN"
+            mapping.column_datatype = "TIMESTAMP"
+            self.operation_matcher.find_best_mapping.return_value = mapping
+            self.entity_config.date_in = "DATE_IN"
+            self.entity_config.remaining_distance = "TRACING_DAYS"
+            self.transformer = MagicMock(transform_value=lambda v, t: v)
+
+        async def update_container_from_tracking(self, container_id, tracking_result):
+            self.updated.append(container_id)
+            return True
+
+    firebird = Do1FirebirdManager()
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    first = TrackingResult(container_number="CONT6")
+    first.last_event = ContainerEvent(
+        date="2025-08-02 12:00",
+        operation="Регистрация ДО1",
+        location="Test",
+    )
+    await engine._write_results_to_firebird([(container, first)])
+
+    second = TrackingResult(container_number="CONT6")
+    second.last_event = ContainerEvent(
+        date="2025-08-04 09:00",
+        operation="Регистрация ДО1",
+        location="Test",
+    )
+    await engine._write_results_to_firebird([(container, second)])
+
+    assert firebird.updated == [6]
+    assert container.current_dates["DATE_IN"] == "2025-08-02 12:00"
+
+
+@pytest.mark.asyncio
+async def test_remaining_distance_updates_only_when_changed():
+    container = ContainerInfo(
+        id=7,
+        container_number="CONT7",
+        line_id=1,
+        current_dates={},
+        remaining_distance=100,
+    )
+
+    class RdFirebirdManager(DummyFirebirdManager):
+        def __init__(self):
+            super().__init__([container])
+            self.operation_matcher.find_best_mapping.return_value = None
+            self.entity_config.remaining_distance = "TRACING_DAYS"
+            self.transformer = MagicMock(transform_value=lambda v, t: v)
+
+        async def update_container_from_tracking(self, container_id, tracking_result):
+            self.updated.append(container_id)
+            container.remaining_distance = tracking_result.last_event.remainingDistance
+            return True
+
+    firebird = RdFirebirdManager()
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    same = TrackingResult(container_number="CONT7")
+    same.last_event = ContainerEvent(
+        date="2024-01-01",
+        operation="X",
+        location="L",
+        remainingDistance=100,
+    )
+    await engine._write_results_to_firebird([(container, same)])
+    assert firebird.updated == []
+
+    changed = TrackingResult(container_number="CONT7")
+    changed.last_event = ContainerEvent(
+        date="2024-01-02",
+        operation="X",
+        location="L",
+        remainingDistance=80,
+    )
+    await engine._write_results_to_firebird([(container, changed)])
+    assert firebird.updated == [7]
+    assert container.remaining_distance == 80

--- a/tests/utils/test_firebird_query.py
+++ b/tests/utils/test_firebird_query.py
@@ -1,0 +1,28 @@
+import os
+import sys
+from unittest.mock import MagicMock
+
+# Ensure project package importable
+dIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+PARENT_DIR = os.path.dirname(dIR)
+if PARENT_DIR not in sys.path:
+    sys.path.insert(0, PARENT_DIR)
+
+import importlib
+
+fm = importlib.import_module('FescoApiParse.utils.db.firebird_manager')
+EntityTableConfig = fm.EntityTableConfig
+FirebirdEntityManager = fm.FirebirdEntityManager
+
+
+def test_build_query_line_or_carrier():
+    mgr = object.__new__(FirebirdEntityManager)
+    mgr.entity_config = EntityTableConfig()
+    mgr.logger = MagicMock()
+    query, params = FirebirdEntityManager._build_selection_query(
+        mgr, {1}, {2}, 0
+    )
+    assert 'LEGAL_PERSON_LINE_ID' in query
+    assert 'LEGAL_PERSON_RAILWAY_CARRIER_ID' in query
+    assert ' OR ' in query
+    assert 1 in params and 2 in params

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -169,6 +169,7 @@ class EntityTableConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS_ID"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # Колонки дат
     date_eta: str = "DATE_ETA"
@@ -277,6 +278,7 @@ class ContainerInfo:
     status_id: Optional[int] = None
     status_name: str = ""
     line_id: Optional[int] = None
+    railway_carrier_id: Optional[int] = None
     priority: int = 0
     remaining_distance: Optional[int] = None
     # created_at: Optional[str] = None
@@ -286,7 +288,7 @@ class ContainerInfo:
     current_dates: Dict[str, Optional[str]] = field(default_factory=dict)
     
     # Флаги обработки
-    processing_flags: Dict[str, bool] = field(default_factory=dict)
+    processing_flags: Dict[str, Any] = field(default_factory=dict)
 
 
 # =============================================================================
@@ -751,6 +753,7 @@ class FirebirdEntityManager:
         self, 
         batch_size: int = 100,
         target_line_ids: Optional[Set[int]] = None,
+        target_carrier_ids: Optional[Set[int]] = None,
         min_priority: int = 0
     ) -> AsyncGenerator[List[ContainerInfo], None]:
         """
@@ -758,7 +761,8 @@ class FirebirdEntityManager:
         
         Args:
             batch_size: Размер батча для обработки
-            target_line_ids: ID линий для фильтрации (если None - все линии)  
+            target_line_ids: ID линий для фильтрации (если None - все линии)
+            target_carrier_ids: ID ЖД перевозчиков (OR-фильтр)
             min_priority: Минимальный приоритет для фильтрации
             
         Yields:
@@ -771,7 +775,7 @@ class FirebirdEntityManager:
                 with self.connection_manager.get_connection() as connection:
                     cursor = connection.cursor()
                     
-                    query, params = self._build_selection_query(target_line_ids, min_priority)
+                    query, params = self._build_selection_query(target_line_ids, target_carrier_ids, min_priority)
                     
                     self.logger.debug(f"🔥 SQL: {query}")
                     self.logger.debug(f"🔥 Params: {params}")
@@ -819,7 +823,8 @@ class FirebirdEntityManager:
     
     def _build_selection_query(
         self, 
-        target_line_ids: Optional[Set[int]], 
+        target_line_ids: Optional[Set[int]],
+        target_carrier_ids: Optional[Set[int]],
         min_priority: int
     ) -> Tuple[str, List[Any]]:
         """Построить SQL запрос для выборки"""
@@ -830,6 +835,7 @@ class FirebirdEntityManager:
             self.entity_config.container_column,
             self.entity_config.status_column,
             self.entity_config.line_column,
+            self.entity_config.railway_carrier_column,
             self.entity_config.date_eta,
             self.entity_config.date_etd,
             self.entity_config.date_in,
@@ -852,11 +858,22 @@ class FirebirdEntityManager:
             query += f" AND {self.entity_config.status_column} NOT IN ({status_placeholders})"
             params.extend([int(s) for s in self.entity_config.excluded_status_ids])
         
-        # Фильтр по линиям
-        if target_line_ids:
+        # Фильтр по линиям и ЖД перевозчикам
+        if target_carrier_ids:
+            line_placeholders = ','.join(['?'] * len(target_line_ids)) if target_line_ids else ''
+            carrier_placeholders = ','.join(['?'] * len(target_carrier_ids))
+            clauses = []
+            if target_line_ids:
+                clauses.append(f"{self.entity_config.line_column} IN ({line_placeholders})")
+                params.extend(list(target_line_ids))
+            clauses.append(f"{self.entity_config.railway_carrier_column} IN ({carrier_placeholders})")
+            params.extend(list(target_carrier_ids))
+            query += " AND (" + " OR ".join(clauses) + ")"
+            self.logger.debug("🔍 OR filter active for line or railway carrier")
+        elif target_line_ids:
             line_placeholders = ','.join(['?'] * len(target_line_ids))
             query += f" AND {self.entity_config.line_column} IN ({line_placeholders})"
-            params.extend(list((target_line_ids)))
+            params.extend(list(target_line_ids))
         
         # Фильтр по приоритету
         if min_priority > 0:
@@ -877,13 +894,14 @@ class FirebirdEntityManager:
             status_id=row[2],
             status_name=self._get_status_name(row[2]),
             line_id=row[3],  # LEGAL_PERSON_LINE_ID
-            remaining_distance=int(row[9]) if row[9] is not None else None,
+            railway_carrier_id=row[4],
+            remaining_distance=int(row[10]) if row[10] is not None else None,
             current_dates={
-                self.entity_config.date_eta: str(row[4]) if row[4] else None,
-                self.entity_config.date_etd: str(row[5]) if row[5] else None,
-                self.entity_config.date_in: str(row[6]) if row[6] else None,
-                self.entity_config.date_railway_loading: str(row[7]) if row[7] else None,
-                self.entity_config.date_railway_delivery: str(row[8]) if row[8] else None,
+                self.entity_config.date_eta: str(row[5]) if row[5] else None,
+                self.entity_config.date_etd: str(row[6]) if row[6] else None,
+                self.entity_config.date_in: str(row[7]) if row[7] else None,
+                self.entity_config.date_railway_loading: str(row[8]) if row[8] else None,
+                self.entity_config.date_railway_delivery: str(row[9]) if row[9] else None,
             },
             processing_flags={'loaded_from_firebird': True}
         )


### PR DESCRIPTION
## Summary
- allow filtering containers by railway carrier or line
- permit one-time DATE_IN override on DO1 registration
- cover remainingDistance updates and OR filter in tests

## Testing
- `pytest FescoApiParse/tests/processing/test_engine.py FescoApiParse/tests/utils/test_firebird_query.py`


------
https://chatgpt.com/codex/tasks/task_e_6895a75bf444832aa43ae7f095ba24e6