### PR TITLE
feat: support railway carrier filter and date-in overrides

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,6 +87,7 @@ class FirebirdDatabaseConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # === КОЛОНКИ ДАТ ===
     date_eta: str = "DATE_ETA"
@@ -99,6 +100,7 @@ class FirebirdDatabaseConfig:
     # === НАСТРОЙКИ ОБРАБОТКИ ===
     excluded_status_ids: List[int] = field(default_factory=lambda: [8, 9, 24])  # закрыто, доставлено, отменено
     target_line_ids: List[int] = field(default_factory=lambda: [451, 751])  # Если пусто - все линии
+    target_railway_carrier_ids: List[int] = field(default_factory=list)
     batch_size: int = 100
     max_connections: int = 10
     
@@ -116,6 +118,14 @@ class FirebirdDatabaseConfig:
         else:
             # Одинарное значение (int/str и др.)
             self.target_line_ids = [int(self.target_line_ids)]
+
+        # Приведение target_railway_carrier_ids к List[int]
+        if isinstance(self.target_railway_carrier_ids, list):
+            self.target_railway_carrier_ids = [int(x) for x in self.target_railway_carrier_ids]
+        elif self.target_railway_carrier_ids is None:
+            self.target_railway_carrier_ids = []
+        else:
+            self.target_railway_carrier_ids = [int(self.target_railway_carrier_ids)]
 
         """Валидация Firebird конфигурации"""
         if not self.host:

--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -76,7 +76,8 @@ class ContainerTrackingEngine:
     async def run_full_workflow(
         self,
         batch_size: int = 100,
-        target_line_ids: Optional[Set[int]] = None
+        target_line_ids: Optional[Set[int]] = None,
+        target_carrier_ids: Optional[Set[int]] = None
     ) -> EngineStats:
         """
         Запуск полного workflow обработки
@@ -90,6 +91,8 @@ class ContainerTrackingEngine:
         """
         if target_line_ids is None:
             target_line_ids = set(self.config.database.target_line_ids)
+        if target_carrier_ids is None:
+            target_carrier_ids = set(self.config.database.target_railway_carrier_ids)
 
         self.logger.info("🚀 Запуск полного workflow трекинга")
         self.logger.info("="*60)
@@ -110,7 +113,8 @@ class ContainerTrackingEngine:
                 # ИЗМЕНЕНО: Читаем контейнеры напрямую из Firebird
                 async for batch in self.firebird_manager.get_containers_for_processing(
                     batch_size=batch_size,
-                    target_line_ids=target_line_ids
+                    target_line_ids=target_line_ids,
+                    target_carrier_ids=target_carrier_ids
                 ):
                     await self._process_container_batch(session, batch)
                     self.engine_stats.firebird_read_batches += 1
@@ -396,26 +400,49 @@ class ContainerTrackingEngine:
                         )
                         continue
 
-                    if stored_value:
-                        parsed_new = self.firebird_manager.transformer.transform_value(
-                            new_value, mapping.column_datatype
+                    parsed_new = self.firebird_manager.transformer.transform_value(
+                        new_value, mapping.column_datatype
+                    )
+                    if parsed_new is None:
+                        self.logger.debug(
+                            f"⏭️ {container_info.container_number}: unable to parse new value for {mapping.entity_column}"
                         )
-                        parsed_stored = self.firebird_manager.transformer.transform_value(
+                        continue
+
+                    parsed_stored = (
+                        self.firebird_manager.transformer.transform_value(
                             stored_value, mapping.column_datatype
                         )
+                        if stored_value
+                        else None
+                    )
 
-                        if (
-                            parsed_new is not None
-                            and parsed_stored is not None
-                            and parsed_new >= parsed_stored
-                        ):
+                    if mapping.entity_column == self.firebird_manager.entity_config.date_in:
+                        operation_lower = (
+                            tracking_result.last_event.operation or ""
+                        ).lower()
+                        do1_names = ("регистрация до1", "do1 registration")
+                        if container_info.processing_flags.get("date_in_do1") and operation_lower in do1_names:
                             self.logger.debug(
-                                f"⏭️ {container_info.container_number}: existing {mapping.entity_column} {stored_value} is earlier"
+                                f"⏭️ {container_info.container_number}: DATE_IN already set by DO1"
                             )
                             continue
-                        if parsed_new is None:
+                        if parsed_stored is not None:
+                            if operation_lower in do1_names:
+                                if parsed_new <= parsed_stored:
+                                    self.logger.debug(
+                                        f"⏭️ {container_info.container_number}: new DATE_IN {new_value} not after {stored_value}"
+                                    )
+                                    continue
+                            elif parsed_new >= parsed_stored:
+                                self.logger.debug(
+                                    f"⏭️ {container_info.container_number}: existing {mapping.entity_column} {stored_value} is earlier"
+                                )
+                                continue
+                    else:
+                        if parsed_stored is not None and parsed_new >= parsed_stored:
                             self.logger.debug(
-                                f"⏭️ {container_info.container_number}: unable to parse new value for {mapping.entity_column}"
+                                f"⏭️ {container_info.container_number}: existing {mapping.entity_column} {stored_value} is earlier"
                             )
                             continue
                 # КЛЮЧЕВОЕ: Используем container_info.id для обновления записи
@@ -430,6 +457,12 @@ class ContainerTrackingEngine:
                         if tracking_result.last_event
                         else container_info.current_dates.get(mapping.entity_column)
                     )
+                    if mapping.entity_column == self.firebird_manager.entity_config.date_in:
+                        op_lower = (
+                            tracking_result.last_event.operation or ""
+                        ).lower()
+                        if op_lower in ("регистрация до1", "do1 registration"):
+                            container_info.processing_flags["date_in_do1"] = True
 
                 if success and new_remaining is not None:
                     container_info.remaining_distance = new_remaining

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -43,7 +43,14 @@ class DummyFirebirdManager:
     def __init__(self, containers):
         self.containers = containers
         self.updated = []
-        self.entity_config = MagicMock(date_railway_loading="DATE_RAILWAY_LOADING")
+        self.entity_config = MagicMock(
+            date_railway_loading="DATE_RAILWAY_LOADING",
+            date_in="DATE_IN",
+            remaining_distance="TRACING_DAYS",
+        )
+        self.transformer = MagicMock(
+            transform_value=lambda v, t: int(v) if t == "INTEGER" and v is not None else v
+        )
         mapping = MagicMock()
         mapping.entity_column = "DATE_ETA"
         self.operation_matcher = MagicMock(find_best_mapping=MagicMock(return_value=mapping))
@@ -51,7 +58,7 @@ class DummyFirebirdManager:
     async def test_connection(self):
         return True
 
-    async def get_containers_for_processing(self, batch_size=100, target_line_ids=None):
+    async def get_containers_for_processing(self, batch_size=100, target_line_ids=None, target_carrier_ids=None):
         yield self.containers
 
     async def update_container_from_tracking(self, container_id, tracking_result):
@@ -161,3 +168,154 @@ async def test_skip_container_with_no_order():
     assert stats.containers_loaded == 1
     assert stats.orders_processed == 0
     assert await engine.binding_manager.is_container_no_order("CONT1") is True
+
+
+@pytest.mark.asyncio
+async def test_date_in_override_from_discharge_to_do1():
+    container = ContainerInfo(
+        id=20,
+        container_number="CONT5",
+        line_id=1,
+        current_dates={"DATE_IN": "2024-01-01"},
+    )
+    firebird = DummyFirebirdManager([container])
+    mapping = MagicMock()
+    mapping.entity_column = "DATE_IN"
+    mapping.column_datatype = "TIMESTAMP"
+    firebird.operation_matcher.find_best_mapping.return_value = mapping
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(
+            date="2024-01-02",
+            operation="Регистрация ДО1",
+            location="Test",
+        )
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == [20]
+
+
+@pytest.mark.asyncio
+async def test_date_in_no_override_after_do1():
+    container = ContainerInfo(
+        id=21,
+        container_number="CONT6",
+        line_id=1,
+        current_dates={"DATE_IN": "2024-01-02"},
+        processing_flags={"date_in_do1": True},
+    )
+    firebird = DummyFirebirdManager([container])
+    mapping = MagicMock()
+    mapping.entity_column = "DATE_IN"
+    mapping.column_datatype = "TIMESTAMP"
+    firebird.operation_matcher.find_best_mapping.return_value = mapping
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(
+            date="2024-01-03",
+            operation="Регистрация ДО1",
+            location="Test",
+        )
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == []
+
+
+@pytest.mark.asyncio
+async def test_remaining_distance_updates():
+    container = ContainerInfo(
+        id=30,
+        container_number="CONT7",
+        line_id=1,
+        remaining_distance=100,
+        current_dates={},
+    )
+    firebird = DummyFirebirdManager([container])
+    firebird.operation_matcher.find_best_mapping.return_value = None
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(
+            date=None,
+            operation="Some op",
+            location="Test",
+            remainingDistance="150",
+        )
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == [30]
+
+
+@pytest.mark.asyncio
+async def test_remaining_distance_skips_when_same():
+    container = ContainerInfo(
+        id=31,
+        container_number="CONT8",
+        line_id=1,
+        remaining_distance=100,
+        current_dates={},
+    )
+    firebird = DummyFirebirdManager([container])
+    firebird.operation_matcher.find_best_mapping.return_value = None
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(
+            date=None,
+            operation="Some op",
+            location="Test",
+            remainingDistance="100",
+        )
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == []

--- a/tests/utils/test_firebird_utils.py
+++ b/tests/utils/test_firebird_utils.py
@@ -1,6 +1,8 @@
 import sys
 import os
+import types
 from datetime import datetime, date
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -84,6 +86,19 @@ def test_detect_database_type():
     assert detect_database_type(fb_config) == "firebird"
     assert detect_database_type(mysql_config) == "mysql"
     assert detect_database_type(pg_config) == "postgresql"
+
+
+def test_build_selection_query_or_filter():
+    fm, _ = _import_firebird_modules()
+    cfg = fm.EntityTableConfig()
+    dummy = types.SimpleNamespace(entity_config=cfg, logger=MagicMock())
+    query, params = fm.FirebirdEntityManager._build_selection_query(
+        dummy, {1}, {2}, 0
+    )
+    assert "OR" in query
+    assert cfg.line_column in query
+    assert cfg.railway_carrier_column in query
+    assert params[-2:] == [1, 2]
 
 
 @pytest.mark.asyncio

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -169,6 +169,7 @@ class EntityTableConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS_ID"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # Колонки дат
     date_eta: str = "DATE_ETA"
@@ -198,7 +199,7 @@ class EntityTableConfig:
             raise ValueError("table_name не может быть пустым")
         
         required_columns = [
-            self.primary_key, self.container_column, 
+            self.primary_key, self.container_column,
             self.status_column, self.line_column
         ]
         
@@ -748,9 +749,10 @@ class FirebirdEntityManager:
     # =========================================================================
     
     async def get_containers_for_processing(
-        self, 
+        self,
         batch_size: int = 100,
         target_line_ids: Optional[Set[int]] = None,
+        target_carrier_ids: Optional[Set[int]] = None,
         min_priority: int = 0
     ) -> AsyncGenerator[List[ContainerInfo], None]:
         """
@@ -771,7 +773,7 @@ class FirebirdEntityManager:
                 with self.connection_manager.get_connection() as connection:
                     cursor = connection.cursor()
                     
-                    query, params = self._build_selection_query(target_line_ids, min_priority)
+                    query, params = self._build_selection_query(target_line_ids, target_carrier_ids, min_priority)
                     
                     self.logger.debug(f"🔥 SQL: {query}")
                     self.logger.debug(f"🔥 Params: {params}")
@@ -818,8 +820,9 @@ class FirebirdEntityManager:
                 yield batch
     
     def _build_selection_query(
-        self, 
-        target_line_ids: Optional[Set[int]], 
+        self,
+        target_line_ids: Optional[Set[int]],
+        target_carrier_ids: Optional[Set[int]],
         min_priority: int
     ) -> Tuple[str, List[Any]]:
         """Построить SQL запрос для выборки"""
@@ -852,11 +855,21 @@ class FirebirdEntityManager:
             query += f" AND {self.entity_config.status_column} NOT IN ({status_placeholders})"
             params.extend([int(s) for s in self.entity_config.excluded_status_ids])
         
-        # Фильтр по линиям
-        if target_line_ids:
+        # Фильтр по линиям/перевозчикам
+        if target_carrier_ids:
+            parts = []
+            if target_line_ids:
+                line_placeholders = ','.join(['?'] * len(target_line_ids))
+                parts.append(f"{self.entity_config.line_column} IN ({line_placeholders})")
+                params.extend(list(target_line_ids))
+            carrier_placeholders = ','.join(['?'] * len(target_carrier_ids))
+            parts.append(f"{self.entity_config.railway_carrier_column} IN ({carrier_placeholders})")
+            params.extend(list(target_carrier_ids))
+            query += f" AND ({' OR '.join(parts)})"
+        elif target_line_ids:
             line_placeholders = ','.join(['?'] * len(target_line_ids))
             query += f" AND {self.entity_config.line_column} IN ({line_placeholders})"
-            params.extend(list((target_line_ids)))
+            params.extend(list(target_line_ids))
         
         # Фильтр по приоритету
         if min_priority > 0:


### PR DESCRIPTION
## Summary
- add optional railway carrier filter combining line and carrier ids
- allow DATE_IN override on "DO1 registration" with guard against further changes
- update remaining distance only when last event changed
- cover OR filtering and tracking rules with unit tests

## Testing
- `pytest tests/utils/test_firebird_utils.py::test_build_selection_query_or_filter -q`
- `pytest tests/processing/test_engine.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6895a766f3d0832a9363a4efe779b259