### PR TITLE
feat: add railway carrier pass and date_in override

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -87,6 +87,7 @@ class FirebirdDatabaseConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # === КОЛОНКИ ДАТ ===
     date_eta: str = "DATE_ETA"
@@ -99,6 +100,7 @@ class FirebirdDatabaseConfig:
     # === НАСТРОЙКИ ОБРАБОТКИ ===
     excluded_status_ids: List[int] = field(default_factory=lambda: [8, 9, 24])  # закрыто, доставлено, отменено
     target_line_ids: List[int] = field(default_factory=lambda: [451, 751])  # Если пусто - все линии
+    target_carrier_ids: Optional[List[int]] = None
     batch_size: int = 100
     max_connections: int = 10
     
@@ -116,6 +118,14 @@ class FirebirdDatabaseConfig:
         else:
             # Одинарное значение (int/str и др.)
             self.target_line_ids = [int(self.target_line_ids)]
+
+        # Приведение target_carrier_ids к List[int]
+        if isinstance(self.target_carrier_ids, list):
+            self.target_carrier_ids = [int(x) for x in self.target_carrier_ids]
+        elif self.target_carrier_ids is None:
+            self.target_carrier_ids = []
+        else:
+            self.target_carrier_ids = [int(self.target_carrier_ids)]
 
         """Валидация Firebird конфигурации"""
         if not self.host:

--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -76,7 +76,8 @@ class ContainerTrackingEngine:
     async def run_full_workflow(
         self,
         batch_size: int = 100,
-        target_line_ids: Optional[Set[int]] = None
+        target_line_ids: Optional[Set[int]] = None,
+        target_carrier_ids: Optional[Set[int]] = None
     ) -> EngineStats:
         """
         Запуск полного workflow обработки
@@ -84,12 +85,18 @@ class ContainerTrackingEngine:
         Args:
             batch_size: Размер батча для обработки контейнеров
             target_line_ids: ID линий для фильтрации (None = все линии)
+            target_carrier_ids: ID ЖД перевозчиков для фильтрации
             
         Returns:
             Статистика выполнения
         """
         if target_line_ids is None:
             target_line_ids = set(self.config.database.target_line_ids)
+        if target_carrier_ids is None:
+            tc = getattr(self.config.database, "target_carrier_ids", [])
+            target_carrier_ids = set(tc or [])
+
+        processed_container_ids: Set[int] = set()
 
         self.logger.info("🚀 Запуск полного workflow трекинга")
         self.logger.info("="*60)
@@ -107,15 +114,40 @@ class ContainerTrackingEngine:
         try:
             async with aiohttp.ClientSession(connector=connector, timeout=timeout) as session:
                 
-                # ИЗМЕНЕНО: Читаем контейнеры напрямую из Firebird
+                self.logger.debug("▶️ Start LINE pass")
+                line_selected = 0
                 async for batch in self.firebird_manager.get_containers_for_processing(
                     batch_size=batch_size,
-                    target_line_ids=target_line_ids
+                    target_ids=target_line_ids
                 ):
+                    line_selected += len(batch)
                     await self._process_container_batch(session, batch)
+                    processed_container_ids.update(c.id for c in batch)
                     self.engine_stats.firebird_read_batches += 1
-                
-                # Финальная статистика
+
+                self.logger.debug(f"✅ Finished LINE pass: {line_selected} containers selected")
+
+                if target_carrier_ids:
+                    self.logger.debug("▶️ Start CARRIER pass")
+                    carrier_selected = 0
+                    async for batch in self.firebird_manager.get_containers_for_processing(
+                        batch_size=batch_size,
+                        target_ids=target_carrier_ids,
+                        selection_column=self.firebird_manager.entity_config.railway_carrier_column
+                    ):
+                        carrier_selected += len(batch)
+                        filtered = [c for c in batch if c.id not in processed_container_ids]
+                        dedup = len(batch) - len(filtered)
+                        if dedup:
+                            self.logger.debug(f"🔁 Deduplicated {dedup} containers in carrier pass")
+                        if not filtered:
+                            continue
+                        await self._process_container_batch(session, filtered)
+                        processed_container_ids.update(c.id for c in filtered)
+                        self.engine_stats.firebird_read_batches += 1
+
+                    self.logger.debug(f"✅ Finished CARRIER pass: {carrier_selected} containers selected")
+
                 await self._log_final_statistics()
                 
         except Exception as e:
@@ -389,6 +421,9 @@ class ContainerTrackingEngine:
                         tracking_result.last_event.date if tracking_result.last_event else None
                     )
                     stored_value = container_info.current_dates.get(mapping.entity_column)
+                    event_name = (
+                        tracking_result.last_event.operation if tracking_result.last_event else ""
+                    )
 
                     if new_value is None:
                         self.logger.debug(
@@ -396,26 +431,62 @@ class ContainerTrackingEngine:
                         )
                         continue
 
-                    if stored_value:
-                        parsed_new = self.firebird_manager.transformer.transform_value(
-                            new_value, mapping.column_datatype
+                    parsed_new = self.firebird_manager.transformer.transform_value(
+                        new_value, mapping.column_datatype
+                    )
+                    if parsed_new is None:
+                        self.logger.debug(
+                            f"⏭️ {container_info.container_number}: unable to parse new value for {mapping.entity_column}"
                         )
+                        continue
+
+                    parsed_stored = None
+                    if stored_value:
                         parsed_stored = self.firebird_manager.transformer.transform_value(
                             stored_value, mapping.column_datatype
                         )
 
+                    date_in_column = self.firebird_manager.entity_config.date_in
+                    if mapping.entity_column == date_in_column:
+                        is_do1 = event_name in ["Регистрация ДО1", "DO1 registration"]
+                        do1_overridden = container_info.processing_flags.get(
+                            "date_in_do1_overridden", False
+                        )
+
+                        if do1_overridden and not is_do1:
+                            self.logger.debug(
+                                f"⏭️ {container_info.container_number}: DATE_IN locked after DO1"
+                            )
+                            continue
+
+                        if is_do1:
+                            if do1_overridden:
+                                self.logger.debug(
+                                    f"⏭️ {container_info.container_number}: DATE_IN already overridden by DO1"
+                                )
+                                continue
+                            container_info.processing_flags[
+                                "date_in_do1_overridden"
+                            ] = True
+                            self.logger.debug(
+                                f"♻️ {container_info.container_number}: DATE_IN override by DO1"
+                            )
+                        else:
+                            if (
+                                parsed_stored is not None and parsed_new >= parsed_stored
+                            ):
+                                self.logger.debug(
+                                    f"⏭️ {container_info.container_number}: existing {mapping.entity_column} {stored_value} is earlier"
+                                )
+                                continue
+                    else:
                         if (
-                            parsed_new is not None
+                            stored_value
                             and parsed_stored is not None
                             and parsed_new >= parsed_stored
                         ):
                             self.logger.debug(
                                 f"⏭️ {container_info.container_number}: existing {mapping.entity_column} {stored_value} is earlier"
-                            )
-                            continue
-                        if parsed_new is None:
-                            self.logger.debug(
-                                f"⏭️ {container_info.container_number}: unable to parse new value for {mapping.entity_column}"
                             )
                             continue
                 # КЛЮЧЕВОЕ: Используем container_info.id для обновления записи

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -16,6 +16,16 @@ from utils.db.firebird_manager import ContainerInfo
 from cache.cache_base import CacheBackend
 
 
+class SimpleTransformer:
+    def transform_value(self, value, datatype):
+        if datatype == "INTEGER":
+            try:
+                return int(value)
+            except Exception:
+                return None
+        return value
+
+
 class DummyCache(CacheBackend):
     def __init__(self):
         self.store = {}
@@ -43,19 +53,26 @@ class DummyFirebirdManager:
     def __init__(self, containers):
         self.containers = containers
         self.updated = []
-        self.entity_config = MagicMock(date_railway_loading="DATE_RAILWAY_LOADING")
+        self.entity_config = MagicMock(
+            date_railway_loading="DATE_RAILWAY_LOADING",
+            date_in="DATE_IN",
+            remaining_distance="TRACING_DAYS",
+            railway_carrier_column="LEGAL_PERSON_RAILWAY_CARRIER_ID",
+        )
         mapping = MagicMock()
         mapping.entity_column = "DATE_ETA"
+        mapping.column_datatype = "DATE"
         self.operation_matcher = MagicMock(find_best_mapping=MagicMock(return_value=mapping))
+        self.transformer = SimpleTransformer()
 
     async def test_connection(self):
         return True
 
-    async def get_containers_for_processing(self, batch_size=100, target_line_ids=None):
+    async def get_containers_for_processing(self, batch_size=100, target_ids=None, selection_column=None):
         yield self.containers
 
     async def update_container_from_tracking(self, container_id, tracking_result):
-        self.updated.append(container_id)
+        self.updated.append((container_id, getattr(tracking_result.last_event, "remainingDistance", None)))
         return True
 
     async def get_entity_statistics(self):
@@ -105,10 +122,10 @@ async def test_run_full_workflow_groups_and_updates():
     assert stats.records_written == 3
     assert stats.orders_processed == 2
     assert sorted(order_calls) == [("ORD1", 2), ("ORD2", 1)]
-    assert firebird.updated == [1, 2, 3]
+    assert firebird.updated == [(1, None), (2, None), (3, None)]
 
 @pytest.mark.asyncio
-async def test_skip_update_if_existing_date_is_earlier():
+async def test_date_mapping_earliest_wins_simple_case():
     container = ContainerInfo(
         id=10,
         container_number="CONT4",
@@ -161,3 +178,198 @@ async def test_skip_container_with_no_order():
     assert stats.containers_loaded == 1
     assert stats.orders_processed == 0
     assert await engine.binding_manager.is_container_no_order("CONT1") is True
+
+
+class TwoPassFirebirdManager:
+    def __init__(self, line_containers, carrier_containers):
+        self.line_containers = line_containers
+        self.carrier_containers = carrier_containers
+        self.updated = []
+        self.entity_config = MagicMock(
+            railway_carrier_column="LEGAL_PERSON_RAILWAY_CARRIER_ID",
+            date_in="DATE_IN",
+            remaining_distance="TRACING_DAYS",
+        )
+        mapping = MagicMock()
+        mapping.entity_column = "DATE_IN"
+        mapping.column_datatype = "TIMESTAMP"
+        self.operation_matcher = MagicMock(find_best_mapping=MagicMock(return_value=mapping))
+        self.transformer = SimpleTransformer()
+
+    async def test_connection(self):
+        return True
+
+    async def get_containers_for_processing(self, batch_size=100, target_ids=None, selection_column=None):
+        if selection_column == self.entity_config.railway_carrier_column:
+            yield list(self.carrier_containers)
+        else:
+            yield list(self.line_containers)
+
+    async def update_container_from_tracking(self, container_id, tracking_result):
+        self.updated.append(container_id)
+        return True
+
+    async def get_entity_statistics(self):
+        return {"runtime_stats": {"records_updated": len(self.updated)}}
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_two_pass_processing_line_then_carrier_dedup():
+    c1 = ContainerInfo(id=1, container_number="CONT1", line_id=1, current_dates={})
+    c2 = ContainerInfo(id=2, container_number="CONT2", line_id=None, current_dates={})
+    firebird = TwoPassFirebirdManager([c1], [c1, c2])
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(date="2024-01-01", operation="Load")
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10, target_line_ids={1}, target_carrier_ids={2})
+
+    assert firebird.updated == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_carrier_only_container_without_line_id_is_processed():
+    c3 = ContainerInfo(id=3, container_number="CONT3", line_id=None, current_dates={})
+    firebird = TwoPassFirebirdManager([], [c3])
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(date="2024-01-01", operation="Load")
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10, target_line_ids={1}, target_carrier_ids={2})
+
+    assert firebird.updated == [3]
+
+
+class CallTrackingFirebirdManager:
+    def __init__(self):
+        self.calls = []
+        self.updated = []
+        self.entity_config = MagicMock(railway_carrier_column="LEGAL_PERSON_RAILWAY_CARRIER_ID", date_in="DATE_IN", remaining_distance="TRACING_DAYS")
+        self.operation_matcher = MagicMock(find_best_mapping=MagicMock(return_value=None))
+        self.transformer = SimpleTransformer()
+
+    async def test_connection(self):
+        return True
+
+    async def get_containers_for_processing(self, batch_size=100, target_ids=None, selection_column=None):
+        self.calls.append(selection_column)
+        yield []
+
+    async def update_container_from_tracking(self, container_id, tracking_result):
+        return True
+
+    async def get_entity_statistics(self):
+        return {"runtime_stats": {"records_updated": 0}}
+
+    async def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_selection_query_line_pass_only_when_no_carrier_ids():
+    firebird = CallTrackingFirebirdManager()
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    await engine.run_full_workflow(batch_size=10, target_line_ids={1})
+
+    assert firebird.calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_date_in_override_discharged_then_do1_once():
+    container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={})
+    firebird = DummyFirebirdManager([])
+    mapping = MagicMock()
+    mapping.entity_column = "DATE_IN"
+    mapping.column_datatype = "TIMESTAMP"
+    firebird.operation_matcher.find_best_mapping.return_value = mapping
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    tr1 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2025-08-01 10:00", operation="Прием с моря"))
+    await engine._write_results_to_firebird([(container, tr1)])
+    assert firebird.updated == [(1, None)]
+    assert container.current_dates["DATE_IN"] == "2025-08-01 10:00"
+
+    tr2 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2025-08-02 12:00", operation="Регистрация ДО1"))
+    await engine._write_results_to_firebird([(container, tr2)])
+    assert firebird.updated == [(1, None), (1, None)]
+    assert container.current_dates["DATE_IN"] == "2025-08-02 12:00"
+    assert container.processing_flags["date_in_do1_overridden"] is True
+
+
+@pytest.mark.asyncio
+async def test_date_in_no_override_after_do1():
+    container = ContainerInfo(
+        id=1,
+        container_number="C1",
+        line_id=1,
+        current_dates={"DATE_IN": "2025-08-02 12:00"},
+        processing_flags={"date_in_do1_overridden": True},
+    )
+    firebird = DummyFirebirdManager([])
+    mapping = MagicMock()
+    mapping.entity_column = "DATE_IN"
+    mapping.column_datatype = "TIMESTAMP"
+    firebird.operation_matcher.find_best_mapping.return_value = mapping
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    tr = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2025-08-03 15:00", operation="Регистрация ДО1"))
+    await engine._write_results_to_firebird([(container, tr)])
+    assert firebird.updated == []
+    assert container.current_dates["DATE_IN"] == "2025-08-02 12:00"
+
+
+@pytest.mark.asyncio
+async def test_remaining_distance_updates_only_on_change_and_is_latest():
+    container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={}, remaining_distance=5)
+    firebird = DummyFirebirdManager([])
+    firebird.operation_matcher.find_best_mapping.return_value = None
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    tr1 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2024-01-01", operation="Op", remainingDistance="5"))
+    await engine._write_results_to_firebird([(container, tr1)])
+    assert firebird.updated == []
+
+    tr2 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2024-01-02", operation="Op", remainingDistance="3"))
+    await engine._write_results_to_firebird([(container, tr2)])
+    assert firebird.updated == [(1, '3')]
+    assert container.remaining_distance == 3
+
+    tr3 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2024-01-03", operation="Op", remainingDistance="3"))
+    await engine._write_results_to_firebird([(container, tr3)])
+    assert firebird.updated == [(1, '3')]

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -169,6 +169,7 @@ class EntityTableConfig:
     container_column: str = "NAME"
     status_column: str = "SP_ENTITY_STATUS_ID"
     line_column: str = "LEGAL_PERSON_LINE_ID"
+    railway_carrier_column: str = "LEGAL_PERSON_RAILWAY_CARRIER_ID"
     
     # Колонки дат
     date_eta: str = "DATE_ETA"
@@ -748,9 +749,10 @@ class FirebirdEntityManager:
     # =========================================================================
     
     async def get_containers_for_processing(
-        self, 
+        self,
         batch_size: int = 100,
-        target_line_ids: Optional[Set[int]] = None,
+        target_ids: Optional[Set[int]] = None,
+        selection_column: Optional[str] = None,
         min_priority: int = 0
     ) -> AsyncGenerator[List[ContainerInfo], None]:
         """
@@ -758,7 +760,8 @@ class FirebirdEntityManager:
         
         Args:
             batch_size: Размер батча для обработки
-            target_line_ids: ID линий для фильтрации (если None - все линии)  
+            target_ids: ID для фильтрации
+            selection_column: колонка для фильтрации
             min_priority: Минимальный приоритет для фильтрации
             
         Yields:
@@ -771,7 +774,7 @@ class FirebirdEntityManager:
                 with self.connection_manager.get_connection() as connection:
                     cursor = connection.cursor()
                     
-                    query, params = self._build_selection_query(target_line_ids, min_priority)
+                    query, params = self._build_selection_query(target_ids, selection_column, min_priority)
                     
                     self.logger.debug(f"🔥 SQL: {query}")
                     self.logger.debug(f"🔥 Params: {params}")
@@ -818,8 +821,9 @@ class FirebirdEntityManager:
                 yield batch
     
     def _build_selection_query(
-        self, 
-        target_line_ids: Optional[Set[int]], 
+        self,
+        target_ids: Optional[Set[int]],
+        selection_column: Optional[str],
         min_priority: int
     ) -> Tuple[str, List[Any]]:
         """Построить SQL запрос для выборки"""
@@ -852,11 +856,12 @@ class FirebirdEntityManager:
             query += f" AND {self.entity_config.status_column} NOT IN ({status_placeholders})"
             params.extend([int(s) for s in self.entity_config.excluded_status_ids])
         
-        # Фильтр по линиям
-        if target_line_ids:
-            line_placeholders = ','.join(['?'] * len(target_line_ids))
-            query += f" AND {self.entity_config.line_column} IN ({line_placeholders})"
-            params.extend(list((target_line_ids)))
+        # Фильтр по переданным ID
+        if target_ids:
+            column = selection_column or self.entity_config.line_column
+            placeholders = ','.join(['?'] * len(target_ids))
+            query += f" AND {column} IN ({placeholders})"
+            params.extend(list(target_ids))
         
         # Фильтр по приоритету
         if min_priority > 0:


### PR DESCRIPTION
## Summary
- support optional railway carrier second pass with deduplication
- add one-time DATE_IN override for DO1 events and respect earliest-date rule
- expand configuration for carrier IDs and column name

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a9d925e70832aadc1ff79f26ebff0