### PR TITLE
Update remaining distance logic

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -454,14 +454,26 @@ class ContainerTrackingEngine:
                 new_rem_raw = tracking_result.last_event.remainingDistance if tracking_result.last_event else None
                 if new_rem_raw is not None:
                     new_rem = self.firebird_manager.transformer.transform_value(new_rem_raw, "INTEGER")
-                    if new_rem is not None and (container_info.remaining_distance is None or new_rem != container_info.remaining_distance):
-                        tr = TrackingResult(container_number=tracking_result.container_number, last_event=ContainerEvent(date=None, operation="", remainingDistance=new_rem_raw))
+                    if new_rem is not None and (
+                        container_info.remaining_distance is None
+                        or new_rem < container_info.remaining_distance
+                    ):
+                        tr = TrackingResult(
+                            container_number=tracking_result.container_number,
+                            last_event=ContainerEvent(
+                                date=None,
+                                operation="",
+                                remainingDistance=new_rem_raw,
+                            ),
+                        )
                         if await self.firebird_manager.update_container_from_tracking(container_info.id, tr):
                             container_info.remaining_distance = new_rem
                             written_count += 1
                             self.engine_stats.firebird_updates += 1
                     else:
-                        self.logger.debug(f"⏭️ {container_info.container_number}: remaining distance unchanged")
+                        self.logger.debug(
+                            f"⏭️ {container_info.container_number}: remaining distance {new_rem} not lower than {container_info.remaining_distance}"
+                        )
             except Exception as e:
                 self.logger.error(f"❌ Ошибка записи {tracking_result.container_number}: {e}")
         self.engine_stats.records_written += written_count

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -383,6 +383,11 @@ async def test_remaining_distance_updates_only_on_change_and_is_latest():
     await engine._write_results_to_firebird([(container, tr3)])
     assert firebird.updated == [(1, '3')]
 
+    tr4 = TrackingResult(container_number="C1", last_event=ContainerEvent(date="2024-01-04", operation="Op", remainingDistance="6"))
+    await engine._write_results_to_firebird([(container, tr4)])
+    assert firebird.updated == [(1, '3')]
+    assert container.remaining_distance == 3
+
 
 @pytest.mark.asyncio
 async def test_date_generic_earliest_wins_across_multiple_events():


### PR DESCRIPTION
## Summary
- only persist remaining distance when value decreases
- add regression test for non-decreasing remaining distance

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c19baea44832a968318634c227e9a