### PR TITLE
Ensure zero remaining distance is preserved

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -512,11 +512,15 @@ class ContainerTrackingEngine:
                     container_num = container.get("containerNumber", "").strip()
                     if container_num in normalized_numbers:
                         last_event = container.get("lastEvent", {})
+                        date = last_event.get("date")
+                        operation = last_event.get("text")
+                        location = last_event.get("location")
+                        remaining = last_event.get("remainingDistance")
                         summary[container_num] = {
-                            "date": (last_event.get("date") or "").strip(),
-                            "operation": (last_event.get("text") or "").strip(),
-                            "location": (last_event.get("location") or "").strip(),
-                            "remainingDistance": str(last_event.get("remainingDistance") or "").strip(),
+                            "date": "" if date is None else str(date).strip(),
+                            "operation": "" if operation is None else str(operation).strip(),
+                            "location": "" if location is None else str(location).strip(),
+                            "remainingDistance": "" if remaining is None else str(remaining).strip(),
                         }
         except Exception as e:
             self.logger.debug(f"Ошибка извлечения сводки: {e}")
@@ -538,13 +542,15 @@ class ContainerTrackingEngine:
             if not result.last_event:
                 continue
             last_event = result.last_event
+            date = last_event.date
+            operation = last_event.operation
+            location = last_event.location
+            remaining = getattr(last_event, "remainingDistance", None)
             event_data = {
-                "date": (last_event.date or "").strip(),
-                "operation": (last_event.operation or "").strip(),
-                "location": (last_event.location or "").strip(),
-                "remainingDistance": str(
-                    getattr(last_event, "remainingDistance", "") or ""
-                ).strip(),
+                "date": "" if date is None else str(date).strip(),
+                "operation": "" if operation is None else str(operation).strip(),
+                "location": "" if location is None else str(location).strip(),
+                "remainingDistance": "" if remaining is None else str(remaining).strip(),
             }
 
             existing = enriched.get(container_num)

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -390,6 +390,57 @@ async def test_remaining_distance_updates_only_on_change_and_is_latest():
 
 
 @pytest.mark.asyncio
+async def test_remaining_distance_zero_cached_and_written():
+    container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={}, remaining_distance=5)
+    firebird = DummyFirebirdManager([container])
+    firebird.operation_matcher.find_best_mapping.return_value = None
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "containers": [
+                        {
+                            "containerNumber": "C1",
+                            "lastEvent": {
+                                "date": "2024-01-01",
+                                "text": "Op",
+                                "location": "Loc",
+                                "remainingDistance": 0,
+                            },
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    async def dummy_process_single_container(self, session, cont, order_id, order_data):
+        return TrackingResult(
+            container_number=cont.container_number,
+            last_event=ContainerEvent(
+                date="2024-01-01",
+                operation="Op",
+                location="Loc",
+                remainingDistance=0,
+            ),
+        )
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == [(1, 0)]
+    assert container.remaining_distance == 0
+    cached = await cache.get("order_last_check:ORD1")
+    assert cached["C1"]["remainingDistance"] == "0"
+
+
+@pytest.mark.asyncio
 async def test_date_generic_earliest_wins_across_multiple_events():
     container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={})
     firebird = DummyFirebirdManager([])

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -1007,10 +1007,10 @@ class FirebirdEntityManager:
         else:
             raw_value = getattr(tracking_result.last_event, date_mapping.fesco_field, None)
         
-        if raw_value:
+        if raw_value is not None:
             # 🔧 КЛЮЧЕВОЕ МЕСТО: выбираем трансформацию по типу колонки
             transformed_value = self.transformer.transform_value(
-                raw_value, 
+                raw_value,
                 date_mapping.column_datatype
             )
             


### PR DESCRIPTION
## Summary
- Handle `0` values when extracting and enriching order summaries so remaining distance is kept
- Allow Firebird manager to transform and write zero values
- Test that remaining distance of zero is cached and written to tracing days

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c3b211938832aa74a7a9b88715123