### PR TITLE
Fix caching for zero remainingDistance events

### DIFF
--- a/processing/events.py
+++ b/processing/events.py
@@ -318,19 +318,19 @@ class EventProcessor:
             return False
         
         # Проверяем наличие хотя бы одного ключевого поля
-        key_fields = ['date', 'location', 'operation', 'text']
+        key_fields = ['date', 'location', 'operation', 'text', 'remainingDistance']
         valid_fields = []
-        
+
         for field in key_fields:
             value = event_data.get(field)
-            if value and str(value).strip():
+            if value is not None and str(value).strip() != "":
                 valid_fields.append(field)
-        
+
         is_valid = len(valid_fields) > 0
-        
+
         if is_valid:
             self.logger.debug(f"✅ Валидное событие с полями: {valid_fields}")
         else:
             self.logger.debug(f"⚠️ Невалидное событие: отсутствуют ключевые поля {key_fields}")
-        
+
         return is_valid

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -441,6 +441,38 @@ async def test_remaining_distance_zero_cached_and_written():
 
 
 @pytest.mark.asyncio
+async def test_remaining_distance_zero_without_other_fields():
+    container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={}, remaining_distance=5)
+    firebird = DummyFirebirdManager([container])
+    firebird.operation_matcher.find_best_mapping.return_value = None
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    engine.api_client.find_order_by_container = AsyncMock(return_value="ORD1")
+    engine.api_client.get_order_tracking = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "containers": [
+                        {"containerNumber": "C1", "lastEvent": {}}
+                    ]
+                }
+            ]
+        }
+    )
+    engine.api_client.get_container_tracking = AsyncMock(
+        return_value={"data": [{"remainingDistance": 0}]}
+    )
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert firebird.updated == [(1, 0)]
+    cached = await cache.get("order_last_check:ORD1")
+    assert cached["C1"]["remainingDistance"] == "0"
+
+
+@pytest.mark.asyncio
 async def test_date_generic_earliest_wins_across_multiple_events():
     container = ContainerInfo(id=1, container_number="C1", line_id=1, current_dates={})
     firebird = DummyFirebirdManager([])


### PR DESCRIPTION
## Summary
- treat `remainingDistance` as a key field and allow zero values when validating event data
- add regression test verifying zero-only remaining distance is cached and written to DB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d3fccc7bc832a9121317a925ad4de