### PR TITLE
Ensure zero remaining distance preserved during event merge

### DIFF
--- a/processing/events.py
+++ b/processing/events.py
@@ -275,8 +275,16 @@ class EventProcessor:
         # Подсчитываем количество заполненных полей
         def count_fields(event: ContainerEvent) -> int:
             filled_fields = 0
-            for field_name in ['date', 'type', 'location', 'operation', 'transport', 'remainingDistance']:
-                if getattr(event, field_name, None):
+            for field_name in [
+                'date',
+                'type',
+                'location',
+                'operation',
+                'transport',
+                'remainingDistance',
+            ]:
+                value = getattr(event, field_name, None)
+                if value is not None and str(value).strip() != "":
                     filled_fields += 1
             return filled_fields
         

--- a/tests/processing/test_events.py
+++ b/tests/processing/test_events.py
@@ -114,3 +114,25 @@ def test_merge_different_events_prefers_container(processor, sample_order_data, 
     assert source == "container"
     assert dedup is False
     assert merged.operation == "Погружен"
+
+
+def test_merge_retains_zero_remaining_distance(processor):
+    order_event = ContainerEvent(
+        date="2024-01-01 10:00:00",
+        location="Vladivostok",
+        operation="Прибыл",
+        remainingDistance="0",
+    )
+
+    container_event = ContainerEvent(
+        date="2024-01-01 10:00:00",
+        location="Vladivostok",
+        operation="Прибыл",
+        type="ARRIVED",
+    )
+
+    merged, dedup, source = processor.merge_and_deduplicate([order_event], [container_event])
+
+    assert source == "merged"
+    assert dedup is True
+    assert merged.remainingDistance == "0"


### PR DESCRIPTION
## Summary
- handle zero-valued fields in event merge decision logic
- add regression test for merging event with only remainingDistance=0

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d5071b750832a99477caa85ba77c7