### PR TITLE
fix: respect smaller remaining distance in merge

### DIFF
--- a/processing/events.py
+++ b/processing/events.py
@@ -199,9 +199,36 @@ class EventProcessor:
         # Проверяем на дубликаты
         if order_event.matches(container_event):
             self.logger.debug("🔄 Найдены дубликаты событий")
-            
+
             # Выбираем более подробное событие
             chosen_event = self._choose_better_event(order_event, container_event)
+
+            # Если оба события содержат remainingDistance и значения отличаются,
+            # выбираем событие с меньшим расстоянием
+            try:
+                rem_order = (
+                    int(order_event.remainingDistance)
+                    if order_event.remainingDistance is not None
+                    and str(order_event.remainingDistance).strip() != ""
+                    else None
+                )
+                rem_container = (
+                    int(container_event.remainingDistance)
+                    if container_event.remainingDistance is not None
+                    and str(container_event.remainingDistance).strip() != ""
+                    else None
+                )
+            except ValueError:
+                rem_order = rem_container = None
+
+            if (
+                rem_order is not None
+                and rem_container is not None
+                and rem_order != rem_container
+            ):
+                chosen_event = (
+                    order_event if rem_order < rem_container else container_event
+                )
             
             # Логируем выбор
             if chosen_event == container_event:

--- a/tests/processing/test_events.py
+++ b/tests/processing/test_events.py
@@ -136,3 +136,27 @@ def test_merge_retains_zero_remaining_distance(processor):
     assert source == "merged"
     assert dedup is True
     assert merged.remainingDistance == "0"
+
+
+def test_merge_prefers_smaller_remaining_distance(processor):
+    order_event = ContainerEvent(
+        date="2024-01-01 10:00:00",
+        location="Vladivostok",
+        operation="Прибыл",
+        remainingDistance="5",
+    )
+
+    container_event = ContainerEvent(
+        date="2024-01-01 10:00:00",
+        location="Vladivostok",
+        operation="Прибыл",
+        remainingDistance="0",
+    )
+
+    merged, dedup, source = processor.merge_and_deduplicate(
+        [order_event], [container_event]
+    )
+
+    assert source == "merged"
+    assert dedup is True
+    assert merged.remainingDistance == "0"


### PR DESCRIPTION
## Summary
- ensure duplicate events favor smaller remainingDistance so zero values are preserved
- cover remaining distance merging edge case with new test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d678c6c8c832a83ae97f9ec91af52