### PR TITLE
Fix caching of zero remaining distance

### DIFF
--- a/processing/events.py
+++ b/processing/events.py
@@ -239,8 +239,39 @@ class EventProcessor:
             self.logger.info(f"🔄 Дедупликация: {chosen_event.operation} в {chosen_event.location}")
             return chosen_event, True, "merged"
         
-        # События разные - берем из контейнера (обычно более актуальные)
-        self.logger.debug("🔍 События не совпадают, выбираем container event")
+        # События разные - сравниваем remainingDistance
+        try:
+            rem_order = (
+                int(order_event.remainingDistance)
+                if order_event.remainingDistance is not None
+                and str(order_event.remainingDistance).strip() != ""
+                else None
+            )
+            rem_container = (
+                int(container_event.remainingDistance)
+                if container_event.remainingDistance is not None
+                and str(container_event.remainingDistance).strip() != ""
+                else None
+            )
+        except ValueError:
+            rem_order = rem_container = None
+
+        if rem_order is not None or rem_container is not None:
+            if rem_container is None or (
+                rem_order is not None and rem_order <= rem_container
+            ):
+                self.logger.info("✅ Выбрано order event (по remainingDistance)")
+                return order_event, False, "order"
+            else:
+                self.logger.info(
+                    "✅ Выбрано container event (по remainingDistance)"
+                )
+                return container_event, False, "container"
+
+        # Если расстояние отсутствует в обоих событиях - выбираем container event
+        self.logger.debug(
+            "🔍 События не совпадают и не содержат remainingDistance, выбираем container event"
+        )
         self.logger.info(f"✅ Выбрано container event: {container_event.operation}")
         return container_event, False, "container"
     

--- a/tests/processing/test_events.py
+++ b/tests/processing/test_events.py
@@ -160,3 +160,27 @@ def test_merge_prefers_smaller_remaining_distance(processor):
     assert source == "merged"
     assert dedup is True
     assert merged.remainingDistance == "0"
+
+
+def test_merge_prefers_smaller_remaining_distance_when_events_differ(processor):
+    order_event = ContainerEvent(
+        date="2024-01-01 10:00:00",
+        location="Loc1",
+        operation="Arrived",
+        remainingDistance="0",
+    )
+
+    container_event = ContainerEvent(
+        date="2024-01-02 10:00:00",
+        location="Loc2",
+        operation="Loaded",
+        remainingDistance="27",
+    )
+
+    merged, dedup, source = processor.merge_and_deduplicate(
+        [order_event], [container_event]
+    )
+
+    assert source == "order"
+    assert dedup is False
+    assert merged.remainingDistance == "0"


### PR DESCRIPTION
## Summary
- choose event with smaller remainingDistance even when events differ to retain zero distance
- test merging when events differ and remainingDistance is smaller

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d7971e9b8832a822afb5eff050d86