### PR TITLE
Normalize container numbers before comparison

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -13,6 +13,7 @@ from cache.cache_base import CacheBackend
 from api.api_client import FescoApiClient
 from processing.container_bindings import ContainerBindingManager
 from processing.events import EventProcessor
+from utils.container_utils import normalize_container_number
 
 # НОВОЕ: Прямой импорт Firebird компонентов
 from utils.db.firebird_manager import (
@@ -246,7 +247,7 @@ class ContainerTrackingEngine:
         Обработка группы контейнеров одной заявки
         """
         
-        container_numbers = [c.container_number.strip() for c in containers]
+        container_numbers = [normalize_container_number(c.container_number) for c in containers]
         self.logger.info(f"📡 Обработка заявки {order_id}: {len(containers)} контейнеров")
         
         try:
@@ -264,8 +265,9 @@ class ContainerTrackingEngine:
             force_update = False
             if last_check_data:
                 for container in containers:
+                    norm_cn = normalize_container_number(container.container_number)
                     cached_rem = int(
-                        last_check_data.get(container.container_number, {}).get("remainingDistance")
+                        last_check_data.get(norm_cn, {}).get("remainingDistance")
                         or 0
                     )
                     if (
@@ -504,12 +506,14 @@ class ContainerTrackingEngine:
         """Извлечь краткую сводку заявки для проверки изменений"""
         
         summary = {}
-        normalized_numbers = {num.strip() for num in container_numbers}
+        normalized_numbers = {normalize_container_number(num) for num in container_numbers}
 
         try:
             for order_item in order_data.get("data", []):
                 for container in order_item.get("containers", []):
-                    container_num = container.get("containerNumber", "").strip()
+                    container_num = normalize_container_number(
+                        container.get("containerNumber", "")
+                    )
                     if container_num in normalized_numbers:
                         last_event = container.get("lastEvent", {})
                         date = last_event.get("date")
@@ -538,7 +542,9 @@ class ContainerTrackingEngine:
         enriched = {k: v.copy() for k, v in summary.items()}
 
         for container_info, result in container_results:
-            container_num = container_info.container_number.strip()
+            container_num = normalize_container_number(
+                container_info.container_number
+            )
             if not result.last_event:
                 continue
             last_event = result.last_event

--- a/processing/events.py
+++ b/processing/events.py
@@ -6,6 +6,7 @@ from models.container_event import ContainerEvent
 from datetime import datetime
 
 from utils.db.firebird_manager import FirebirdDateTransformer
+from utils.container_utils import normalize_container_number
 
 from utils.logging import get_logger
 
@@ -45,30 +46,31 @@ class EventProcessor:
         """
         
         self.logger.debug(f"📦 Извлечение order events для {container_number}")
-        
+
         events = []
-        
+        normalized_arg = normalize_container_number(container_number)
+
         try:
             data_items = order_data.get("data", [])
             self.logger.debug(f"📊 Получено {len(data_items)} элементов данных заявки")
-            
+
             for order_item in data_items:
                 # Проверяем соответствие номера заявки
                 item_order_id = str(order_item.get("orderNumber", ""))
                 if item_order_id != str(order_id):
                     self.logger.debug(f"⏭️ Пропускаем заявку {item_order_id} (ищем {order_id})")
                     continue
-                
+
                 # Ищем нужный контейнер
                 containers = order_item.get("containers", [])
                 self.logger.debug(f"🔍 Проверяем {len(containers)} контейнеров в заявке {order_id}")
-                
+
                 for container in containers:
-                    container_num = container.get("containerNumber", "").strip()
-                    if container_num != container_number.strip():
+                    container_num = normalize_container_number(container.get("containerNumber", ""))
+                    if container_num != normalized_arg:
                         self.logger.debug(f"⏭️ Пропускаем контейнер {container_num}")
                         continue
-                    
+
                     # Извлекаем последнее событие
                     last_event = container.get("lastEvent", {})
                     if self._is_valid_event_data(last_event):
@@ -79,15 +81,15 @@ class EventProcessor:
                             remainingDistance=last_event.get("remainingDistance")
                         )
                         events.append(event)
-                        
+
                         self.logger.debug(f"📦 Order event найден: {event.operation} в {event.location}")
                     else:
                         self.logger.debug("⚠️ Последнее событие пустое или невалидное")
-            
+
         except Exception as e:
             self.logger.error(f"❌ Ошибка извлечения order events: {e}")
             self.logger.debug("🔍 Детали ошибки:", exc_info=True)
-        
+
         self.logger.debug(f"✅ Извлечено {len(events)} order events")
         return events
     

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -634,3 +634,42 @@ async def test_timezone_normalization_correct_comparison():
 
     assert container.current_dates["DATE_ETA"] == "2024-01-01T00:00:00+03:00"
     assert firebird.updated == []
+
+
+def test_extract_order_summary_normalizes_and_handles_zero():
+    firebird = DummyFirebirdManager([])
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    engine = ContainerTrackingEngine(config, cache, firebird)
+
+    order_data = {
+        "data": [
+            {
+                "orderNumber": "ORD1",
+                "containers": [
+                    {
+                        "containerNumber": "co nt1",
+                        "lastEvent": {
+                            "date": "2024-01-01",
+                            "text": "Load",
+                            "location": "Loc",
+                            "remainingDistance": 0,
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    summary = engine._extract_order_summary(order_data, ["CONT1"])
+    assert summary == {
+        "CONT1": {
+            "date": "2024-01-01",
+            "operation": "Load",
+            "location": "Loc",
+            "remainingDistance": "0",
+        }
+    }
+
+    cached = {"CONT1": summary["CONT1"].copy()}
+    assert engine._data_unchanged(cached, summary)

--- a/tests/processing/test_events.py
+++ b/tests/processing/test_events.py
@@ -82,6 +82,31 @@ def test_extract_container_events(processor, sample_container_data):
     assert event.transport == "Ship"
 
 
+def test_extract_order_events_normalizes_numbers(processor):
+    order_data = {
+        "data": [
+            {
+                "orderNumber": "ORD123",
+                "containers": [
+                    {
+                        "containerNumber": "co nt1",  # mixed case with spaces
+                        "lastEvent": {
+                            "date": "2024-01-01 10:00:00",
+                            "location": "Vladivostok",
+                            "text": "Прибыл",
+                        },
+                    }
+                ],
+            }
+        ]
+    }
+
+    # incoming container number also contains spaces/case
+    events = processor.extract_order_events(order_data, "ORD123", " C ONT1 ")
+    assert len(events) == 1
+    assert events[0].operation == "Прибыл"
+
+
 def test_merge_only_order_events(processor, sample_order_data):
     order_events = processor.extract_order_events(sample_order_data, "ORD123", "CONT1")
     merged, dedup, source = processor.merge_and_deduplicate(order_events, [])

--- a/utils/container_utils.py
+++ b/utils/container_utils.py
@@ -1,0 +1,21 @@
+"""Utility helpers for container number handling."""
+
+
+def normalize_container_number(number: str) -> str:
+    """Normalize container numbers for comparisons.
+
+    Removes all whitespace characters and uppercases the result. If ``number`` is
+    falsy or not a string, an empty string is returned.
+
+    Args:
+        number: The container number to normalize.
+
+    Returns:
+        Normalized container number.
+    """
+
+    if not isinstance(number, str):
+        return ""
+    # ``split`` without arguments removes all whitespace characters.
+    return "".join(number.split()).upper()
+


### PR DESCRIPTION
## Summary
- add `normalize_container_number` helper to strip whitespace and uppercase container numbers
- use normalization in event extraction, order summary generation, and order group processing to compare containers consistently
- extend tests to handle container numbers with spaces and ensure remainingDistance `0` caching works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d81d90d34832abb267ef2280fd31e