### PR TITLE
Add station mapping and Google Sheets sync modules

### DIFF
--- a/processing/google_sheets_sync.py
+++ b/processing/google_sheets_sync.py
@@ -1,0 +1,188 @@
+"""Utilities for synchronising data with Google Sheets.
+
+This module implements the behaviour described in task 2. The logic is kept
+framework agnostic so that unit tests can use a lightweight in-memory
+``Worksheet`` replacement. When used in production a real gspread worksheet can
+be supplied.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Optional, Callable
+from zoneinfo import ZoneInfo
+
+from utils.logging import get_logger
+
+try:  # pragma: no cover - optional dependency for real usage
+    import gspread  # type: ignore
+except Exception:  # pragma: no cover
+    gspread = None  # type: ignore
+
+logger = get_logger("google_sheets_sync")
+
+
+@dataclass
+class SheetRow:
+    """Representation of a row in the target Google Sheet."""
+
+    container: str
+    loading_date: str
+    tracking_date: str
+    operation: str
+    distance: float
+    station_name: str
+
+    def to_list(self) -> list[str]:
+        return [
+            self.container,
+            self.loading_date,
+            self.tracking_date,
+            self.operation,
+            str(self.distance),
+            self.station_name,
+        ]
+
+
+class WorksheetAdapter:
+    """Minimal interface used by :class:`GoogleSheetsSync`.
+
+    Real gspread worksheets already provide ``append_row`` and ``batch_update``
+    methods. The adapter allows simple in-memory implementations for tests.
+    """
+
+    def __init__(self, worksheet):
+        self.worksheet = worksheet
+
+    def find_row(self, container: str) -> Optional[int]:
+        if hasattr(self.worksheet, "find_row"):
+            return self.worksheet.find_row(container)
+        try:  # pragma: no cover - real gspread
+            cell = self.worksheet.find(container)
+            return cell.row - 1
+        except Exception:
+            return None
+
+    def get_row(self, index: int) -> Dict[str, str]:
+        if hasattr(self.worksheet, "get_row"):
+            return self.worksheet.get_row(index)
+        # pragma: no cover - real gspread
+        values = self.worksheet.row_values(index + 1)
+        headers = [
+            "Контейнер",
+            "Отгрузка на ЖД",
+            "Дата обновления слежения",
+            "Операция",
+            "Расстояние до станции назначения",
+            "Станция местоположения",
+        ]
+        return dict(zip(headers, values))
+
+    def append_row(self, row: SheetRow) -> None:
+        if hasattr(self.worksheet, "append_row"):
+            self.worksheet.append_row(row)
+        else:  # pragma: no cover - real gspread
+            self.worksheet.append_row(row.to_list(), value_input_option="USER_ENTERED")
+
+    def update_row(self, index: int, row: SheetRow) -> None:
+        if hasattr(self.worksheet, "update_row"):
+            self.worksheet.update_row(index, row)
+        else:  # pragma: no cover - real gspread
+            rng = f"A{index+1}:F{index+1}"
+            self.worksheet.batch_update([{ "range": rng, "values": [row.to_list()]}])
+
+
+class GoogleSheetsSync:
+    """Synchronise container data with a Google Sheet."""
+
+    def __init__(
+        self,
+        worksheet: WorksheetAdapter,
+        timezone: str = "Asia/Vladivostok",
+        now_func: Callable[[], datetime] | None = None,
+    ):
+        self.ws = worksheet
+        self.tz = ZoneInfo(timezone)
+        self.now_func = now_func or (lambda: datetime.now(self.tz))
+        self.logger = get_logger("google_sheets_sync")
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def map_operation(
+        status: Optional[str],
+        distance: float,
+        at_destination: bool,
+        stagnant_days: int = 0,
+    ) -> str:
+        """Map arbitrary *status* to one of three allowed values."""
+        allowed = {
+            "в пути": "В пути",
+            "прибыл на станцию назначения": "прибыл на станцию назначения",
+            "простой в пути": "простой в пути",
+        }
+        if status:
+            key = status.strip().lower()
+            if key in allowed:
+                return allowed[key]
+
+        if at_destination and distance == 0:
+            return "прибыл на станцию назначения"
+        if stagnant_days >= 1:
+            return "простой в пути"
+        return "В пути"
+
+    # ------------------------------------------------------------------
+    def sync_row(self, data: Dict[str, object], stagnant_days: int = 0) -> bool:
+        """Upsert a single row in the worksheet.
+
+        Parameters
+        ----------
+        data:
+            Dictionary with keys ``Контейнер``, ``Отгрузка на ЖД``,
+            ``Расстояние до станции назначения``, ``Станция местоположения`` and
+            optionally ``Операция`` and ``Дата обновления слежения``.
+        stagnant_days:
+            Number of days without movement used to detect the "простой в пути"
+            status.
+        """
+        container = str(data["Контейнер"])
+        distance = float(data["Расстояние до станции назначения"])
+        station_name = str(data["Станция местоположения"])
+        loading_date = str(data["Отгрузка на ЖД"])
+        status = data.get("Операция")
+        at_destination = bool(data.get("at_destination", False))
+        operation = self.map_operation(status, distance, at_destination, stagnant_days)
+
+        existing_index = self.ws.find_row(container)
+        today = self.now_func().strftime("%d-%m-%Y")
+
+        if existing_index is None:
+            row = SheetRow(container, loading_date, today, operation, distance, station_name)
+            self.ws.append_row(row)
+            self.logger.info("Row added for %s", container)
+            return True
+
+        current = self.ws.get_row(existing_index)
+        tracking_date = current.get("Дата обновления слежения", today)
+        row = SheetRow(
+            container,
+            loading_date,
+            tracking_date,
+            operation,
+            distance,
+            station_name,
+        )
+
+        # Update tracking date only when distance changed
+        try:
+            existing_distance = float(
+                current.get("Расстояние до станции назначения", distance)
+            )
+        except ValueError:
+            existing_distance = distance
+        if existing_distance != distance:
+            row.tracking_date = today
+
+        self.ws.update_row(existing_index, row)
+        self.logger.info("Row updated for %s", container)
+        return existing_distance != distance

--- a/processing/station_mapper.py
+++ b/processing/station_mapper.py
@@ -1,0 +1,219 @@
+"""Utilities for mapping location names to railway station IDs and updating entity records.
+
+This module implements the logic required by task 1:
+    * normalisation of location names
+    * mapping to station identifiers from ``SP_RAILWAY_STATION``
+    * updating ``ENTITY.SP_RAILWAY_CURRENT_STATION_ID`` only when the value changes
+    * logging all performed updates
+
+The implementation relies only on the existing Firebird utilities and logging
+modules.  The database schema is intentionally simple – only the fields used in
+this task are queried.
+
+The main entry points are :class:`StationMapper` and
+:class:`EntityStationUpdater`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Dict, Optional, Iterable
+
+from utils.logging import get_logger
+
+try:
+    # Firebird utilities are optional during tests – they are not available on
+    # CI.  The code is structured so that the mapper can be used without an
+    # actual connection manager (for unit tests).
+    from utils.db.firebird_manager import FirebirdConnectionManager
+except Exception:  # pragma: no cover - fallback for tests
+    FirebirdConnectionManager = None  # type: ignore
+
+logger = get_logger("station_mapper")
+
+
+_STATION_PREFIXES = [
+    r"^СТ\.?\s*",  # «ст.» or станция
+    r"^СТАНЦИЯ\s*",
+    r"^Г\.?\s*",
+]
+_SUFFIX_PATTERN = re.compile(r"[\.,]\s*$")
+
+
+def normalize_station_name(name: str) -> str:
+    """Return a normalised representation of *name*.
+
+    The function performs the following transformations:
+
+    * trim leading/trailing whitespace
+    * remove common prefixes like ``ст.``, ``станция`` or ``г.``
+    * collapse multiple spaces and hyphens
+    * convert to upper case
+
+    Parameters
+    ----------
+    name:
+        Raw location name from the API/cache.
+    """
+    if not name:
+        return ""
+
+    result = name.strip().upper()
+
+    for pattern in _STATION_PREFIXES:
+        result = re.sub(pattern, "", result)
+
+    result = re.sub(r"[\s\-]+", " ", result)
+    result = _SUFFIX_PATTERN.sub("", result)
+    return result.strip()
+
+
+@dataclass
+class StationMapper:
+    """Map normalised station names to station IDs.
+
+    Parameters
+    ----------
+    connection_manager:
+        Optional :class:`FirebirdConnectionManager`.  When omitted the mapper can
+        still be used by manually populating ``stations`` and ``aliases`` – this
+        is convenient for unit tests.
+    """
+
+    connection_manager: Optional[FirebirdConnectionManager] = None
+    stations: Dict[str, int] | None = None
+    aliases: Dict[str, int] | None = None
+
+    def _load(self) -> None:
+        """Load station names and aliases from the database if not cached."""
+        if self.stations is not None and self.aliases is not None:
+            return
+
+        self.stations = {}
+        self.aliases = {}
+        if not self.connection_manager:
+            logger.debug("No connection manager supplied; using empty station map")
+            return
+
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute("SELECT ID, NAME FROM SP_RAILWAY_STATION")
+            for station_id, name in cursor.fetchall():
+                self.stations[normalize_station_name(name)] = station_id
+
+            # Aliases are optional – some installations may not have a separate
+            # table.  We try to load it but ignore errors.
+            try:
+                cursor.execute("SELECT STATION_ID, ALIAS FROM SP_RAILWAY_STATION_ALIAS")
+                for station_id, alias in cursor.fetchall():
+                    self.aliases[normalize_station_name(alias)] = station_id
+            except Exception:  # pragma: no cover - optional table
+                pass
+
+    def find_station_id(self, location: str) -> Optional[int]:
+        """Return station id for *location* or ``None`` if not resolvable."""
+        self._load()
+        if not location:
+            return None
+
+        assert self.stations is not None and self.aliases is not None
+
+        norm = normalize_station_name(location)
+        if norm in self.stations:
+            return self.stations[norm]
+        if norm in self.aliases:
+            return self.aliases[norm]
+
+        # Partial match – collect all station IDs whose names start with the
+        # normalised string.  Only a single unique match is accepted.
+        matches = {sid for name, sid in self.stations.items() if name.startswith(norm)}
+        if len(matches) == 1:
+            return matches.pop()
+        return None
+
+
+class EntityStationUpdater:
+    """Update ``ENTITY.SP_RAILWAY_CURRENT_STATION_ID`` based on cache data."""
+
+    def __init__(self, connection_manager: FirebirdConnectionManager, mapper: StationMapper):
+        if connection_manager is None:
+            raise ValueError("connection_manager is required")
+        self.connection_manager = connection_manager
+        self.mapper = mapper
+        self.logger = get_logger("station_updater")
+
+    def update_entity(self, entity_id: int, location: str, source: str = "cache") -> bool:
+        """Update the station id for *entity_id*.
+
+        Parameters
+        ----------
+        entity_id:
+            Identifier of the ENTITY record.
+        location:
+            Raw location string from cache.
+        source:
+            Source description for logging purposes.
+
+        Returns
+        -------
+        bool
+            ``True`` if the value was updated, ``False`` otherwise.
+        """
+        station_id = self.mapper.find_station_id(location)
+        if station_id is None:
+            self.logger.info(
+                "❔ Unable to resolve station for entity %s: %s", entity_id, location
+            )
+            return False
+
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT SP_RAILWAY_CURRENT_STATION_ID FROM ENTITY WHERE ID = ?",
+                (entity_id,),
+            )
+            row = cursor.fetchone()
+            current_id = row[0] if row else None
+
+            if current_id == station_id:
+                self.logger.debug(
+                    "Entity %s already has station %s", entity_id, station_id
+                )
+                return False
+
+            cursor.execute(
+                """
+                UPDATE ENTITY
+                SET SP_RAILWAY_CURRENT_STATION_ID = ?,
+                    UPDATED_AT = CURRENT_TIMESTAMP
+                WHERE ID = ?
+                """,
+                (station_id, entity_id),
+            )
+            connection.commit()
+
+        self.logger.info(
+            "✅ Entity %s station updated: %s → %s (source: %s)",
+            entity_id,
+            current_id,
+            station_id,
+            source,
+        )
+        return True
+
+    def process_records(self, records: Iterable[Dict[str, str]]) -> Dict[str, int]:
+        """Process multiple cache *records*.
+
+        Each record must contain ``entity_id`` and ``location`` keys.  The method
+        returns a summary dictionary with counts of updated and skipped records.
+        """
+        updated = 0
+        skipped = 0
+        for rec in records:
+            entity_id = int(rec["entity_id"])
+            location = rec.get("location") or ""
+            if self.update_entity(entity_id, location):
+                updated += 1
+            else:
+                skipped += 1
+        return {"updated": updated, "skipped": skipped}

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pytest==8.4.1
 pytest-asyncio==1.1.0
 fakeredis==2.30.1
 APScheduler>=3.10
+gspread==6.1.2

--- a/tests/processing/test_google_sheets_sync.py
+++ b/tests/processing/test_google_sheets_sync.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from datetime import datetime
+
+from processing.google_sheets_sync import WorksheetAdapter, GoogleSheetsSync, SheetRow
+
+
+class FakeWorksheet:
+    def __init__(self):
+        self.rows = []  # list of SheetRow
+
+    def find_row(self, container):
+        for idx, row in enumerate(self.rows):
+            if row.container == container:
+                return idx
+        return None
+
+    def get_row(self, index):
+        row = self.rows[index]
+        return {
+            "Контейнер": row.container,
+            "Отгрузка на ЖД": row.loading_date,
+            "Дата обновления слежения": row.tracking_date,
+            "Операция": row.operation,
+            "Расстояние до станции назначения": row.distance,
+            "Станция местоположения": row.station_name,
+        }
+
+    def append_row(self, row):
+        self.rows.append(row)
+
+    def update_row(self, index, row):
+        self.rows[index] = row
+
+
+def test_map_operation_rules():
+    assert GoogleSheetsSync.map_operation(None, 10, False, 0) == "В пути"
+    assert GoogleSheetsSync.map_operation("прибыл на станцию назначения", 0, True) == "прибыл на станцию назначения"
+    assert GoogleSheetsSync.map_operation("что-то", 0, True) == "прибыл на станцию назначения"
+    assert GoogleSheetsSync.map_operation("что-то", 5, False, 2) == "простой в пути"
+
+
+def test_upsert_updates_tracking_date_only_on_distance_change():
+    sheet = WorksheetAdapter(FakeWorksheet())
+    fixed_now = lambda: datetime(2025, 9, 8, 10, 0, 0)
+    sync = GoogleSheetsSync(sheet, now_func=fixed_now)
+
+    data = {
+        "Контейнер": "MSCU1234567",
+        "Отгрузка на ЖД": "01-09-2025",
+        "Расстояние до станции назначения": 225.0,
+        "Станция местоположения": "Москва",
+        "Операция": "В пути",
+    }
+    sync.sync_row(data)
+    assert len(sheet.worksheet.rows) == 1
+    first_date = sheet.worksheet.rows[0].tracking_date
+
+    # Second call with same distance -> date not changed
+    sync.sync_row(data)
+    assert sheet.worksheet.rows[0].tracking_date == first_date
+
+    # Third call with changed distance -> date updated
+    sync.now_func = lambda: datetime(2025, 9, 9, 10, 0, 0)
+    data["Расстояние до станции назначения"] = 218.0
+    sync.sync_row(data)
+    assert sheet.worksheet.rows[0].tracking_date == "09-09-2025"
+    assert sheet.worksheet.rows[0].distance == 218.0

--- a/tests/processing/test_station_mapper.py
+++ b/tests/processing/test_station_mapper.py
@@ -1,0 +1,54 @@
+import pytest
+from unittest.mock import MagicMock
+
+from processing.station_mapper import (
+    normalize_station_name,
+    StationMapper,
+    EntityStationUpdater,
+)
+
+
+def test_normalize_station_name():
+    assert normalize_station_name(' ст. Москва - Каланчёвская ') == 'МОСКВА КАЛАНЧЁВСКАЯ'
+    assert normalize_station_name('г. Владивосток') == 'ВЛАДИВОСТОК'
+
+
+def test_station_mapper_match_with_alias_and_partial():
+    mapper = StationMapper()
+    mapper.stations = {'МОСКВА КАЛАНЧЁВСКАЯ': 1, 'МОСКВА ТОВАРНАЯ': 3}
+    mapper.aliases = {'МОСКВА КАЛАНЧЕВСКАЯ': 1}
+
+    assert mapper.find_station_id('Москва-Каланчёвская') == 1
+    assert mapper.find_station_id('Москва-Кал') == 1
+    assert mapper.find_station_id('Москва') is None  # ambiguous
+
+
+def test_entity_station_updater_updates_only_on_change():
+    connection = MagicMock()
+    cursor = MagicMock()
+    connection.cursor.return_value = cursor
+    connection.__enter__.return_value = connection
+    cursor.fetchone.return_value = (2,)
+
+    conn_manager = MagicMock()
+    conn_manager.get_connection.return_value = connection
+
+    mapper = MagicMock()
+    mapper.find_station_id.return_value = 1
+
+    updater = EntityStationUpdater(conn_manager, mapper)
+    assert updater.update_entity(5, 'Москва') is True
+    cursor.execute.assert_any_call(
+        'SELECT SP_RAILWAY_CURRENT_STATION_ID FROM ENTITY WHERE ID = ?', (5,)
+    )
+    # second execute corresponds to UPDATE query
+    update_call = cursor.execute.call_args_list[1]
+    assert update_call[0][1] == (1, 5)
+    assert 'UPDATE ENTITY' in update_call[0][0]
+
+    cursor.reset_mock()
+    cursor.fetchone.return_value = (1,)
+    assert updater.update_entity(5, 'Москва') is False
+    cursor.execute.assert_called_once_with(
+        'SELECT SP_RAILWAY_CURRENT_STATION_ID FROM ENTITY WHERE ID = ?', (5,)
+    )

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -83,7 +83,6 @@ class EntityStatusID(IntEnum):
     FTL_RELEASE = 58 # "04...Выпуск FTL"
 
     
-    class ENTITY_CURRENT_STATION_ID(IntEnum):
         
 
 


### PR DESCRIPTION
## Summary
- map `location` strings to station IDs and persist them to `ENTITY.SP_RAILWAY_CURRENT_STATION_ID`
- add Google Sheets synchronisation helper with upsert and operation mapping
- include gspread dependency and fix firebird manager enum typo

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: test_update_remaining_distance_when_date_skipped, test_merge_prefers_smaller_remaining_distance)*


------
https://chatgpt.com/codex/tasks/task_e_68be362d89f8832aa619e302291668c2