### PR TITLE
Add station mapping and Google Sheets sync modules

### DIFF
--- a/processing/events.py
+++ b/processing/events.py
@@ -176,10 +176,23 @@ class EventProcessor:
         self.logger.debug("🔀 Объединение событий из двух источников")
         final_event, has_duplicates, source = self._merge_events(order_events, container_events)
 
-        # Используем значение remainingDistance из заявки, если оно есть
+        # Используем значение remainingDistance из заявки,
+        # но только если оно меньше уже выбранного значения
         best_order_event = self._get_best_event(order_events)
         if best_order_event and best_order_event.remainingDistance:
-            final_event.remainingDistance = best_order_event.remainingDistance
+            try:
+                current_rem = (
+                    int(final_event.remainingDistance)
+                    if final_event and final_event.remainingDistance not in (None, "")
+                    else None
+                )
+                order_rem = int(best_order_event.remainingDistance)
+            except ValueError:
+                current_rem = None
+                order_rem = None
+
+            if current_rem is None or (order_rem is not None and order_rem < current_rem):
+                final_event.remainingDistance = best_order_event.remainingDistance
 
         return final_event, has_duplicates, source
     

--- a/processing/google_sheets_sync.py
+++ b/processing/google_sheets_sync.py
@@ -1,0 +1,108 @@
+"""Synchronise container tracking data with Google Sheets."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Any, Optional
+from zoneinfo import ZoneInfo
+
+from utils.logging import get_logger
+from utils.db.firebird_manager import FirebirdEntityManager
+
+
+ALLOWED_OPERATIONS = {
+    "В пути",
+    "прибыл на станцию назначения",
+    "простой в пути",
+}
+
+
+@dataclass
+class SheetRow:
+    container: str
+    railway_loading: str
+    distance: float
+    station_id: Optional[int]
+    operation: Optional[str] = None
+    destination_station: Optional[str] = None
+
+
+class SheetInterface:
+    """Simple interface for sheet operations used for testing."""
+
+    def get(self, container: str) -> Optional[Dict[str, Any]]:  # pragma: no cover - interface
+        raise NotImplementedError
+
+    def update(self, container: str, data: Dict[str, Any]) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+    def add(self, data: Dict[str, Any]) -> None:  # pragma: no cover
+        raise NotImplementedError
+
+
+class GoogleSheetsSync:
+    """Synchronise data with Google Sheets keeping business rules."""
+
+    def __init__(self, sheet: SheetInterface, firebird: FirebirdEntityManager, timezone: str = "Asia/Vladivostok"):
+        self.sheet = sheet
+        self.firebird = firebird
+        self.tz = ZoneInfo(timezone)
+        self.logger = get_logger("google_sheets_sync")
+
+    # ------------------------------------------------------------------
+    def _today_str(self) -> str:
+        return datetime.now(self.tz).date().isoformat()
+
+    # ------------------------------------------------------------------
+    async def _station_name(self, station_id: Optional[int]) -> str:
+        if station_id is None:
+            return ""
+        name = await self.firebird.get_station_name_by_id(station_id)
+        return name or ""
+
+    def _map_operation(
+        self,
+        raw_operation: Optional[str],
+        distance: float,
+        station_name: str,
+        destination: Optional[str],
+        previous_distance: Optional[float] = None,
+    ) -> str:
+        if raw_operation:
+            op = raw_operation.strip().lower()
+            if op in {"в пути", "простой в пути", "прибыл на станцию назначения"}:
+                return raw_operation.strip()
+        # Fallback rules
+        if distance == 0 and destination and station_name and station_name == destination:
+            return "прибыл на станцию назначения"
+        return "В пути" if distance >= 0 else "В пути"
+
+    async def upsert_row(self, row: SheetRow) -> None:
+        """Insert or update a row in the sheet according to rules."""
+        existing = self.sheet.get(row.container)
+        station_name = await self._station_name(row.station_id)
+
+        today = self._today_str()
+        data = {
+            "Контейнер": row.container,
+            "Отгрузка на ЖД": row.railway_loading,
+            "Расстояние до станции назначения": row.distance,
+            "Станция местоположения": station_name,
+        }
+
+        op = self._map_operation(row.operation, row.distance, station_name, row.destination_station)
+        data["Операция"] = op
+
+        if existing:
+            prev_dist = existing.get("Расстояние до станции назначения")
+            prev_date = existing.get("Дата обновления слежения")
+            if prev_dist is None or float(prev_dist) != float(row.distance):
+                data["Дата обновления слежения"] = today
+            else:
+                data["Дата обновления слежения"] = prev_date
+            self.sheet.update(row.container, data)
+        else:
+            data["Дата обновления слежения"] = today
+            self.sheet.add(data)
+
+        self.logger.info(f"Синхронизирован контейнер {row.container}")

--- a/processing/station_updater.py
+++ b/processing/station_updater.py
@@ -1,0 +1,94 @@
+"""Utilities for mapping API location to railway station IDs and updating the ENTITY table."""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Any, Optional
+
+from utils.logging import get_logger
+from utils.db.firebird_manager import FirebirdEntityManager
+
+
+@dataclass
+class CacheRecord:
+    entity_id: int
+    location: str
+    sp_station: Optional[str] = None
+
+
+class StationUpdater:
+    """Resolve station IDs from API location strings and store them in Firebird."""
+
+    def __init__(self, firebird: FirebirdEntityManager):
+        self.firebird = firebird
+        self.logger = get_logger("station_updater")
+
+    # ------------------------------------------------------------------
+    # Normalisation helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def normalize(name: str) -> str:
+        if not name:
+            return ""
+        name = name.strip().upper()
+        # remove common prefixes like "СТ.", "СТАНЦИЯ", "Г." etc
+        name = re.sub(r"\bСТ\.?\b", " ", name)
+        name = name.replace("СТАНЦИЯ", "")
+        name = name.replace("ГОРОД", "")
+        name = name.replace("Г.", "")
+        name = re.sub(r"[\.,]", " ", name)
+        name = re.sub(r"\s+", " ", name)
+        return name.strip()
+
+    # ------------------------------------------------------------------
+    async def resolve_station_id(self, location: str, sp_station: Optional[str] = None) -> Optional[int]:
+        """Determine station ID using explicit field or by name lookup."""
+        if sp_station:
+            sp_station = sp_station.strip()
+            if sp_station.isdigit():
+                return int(sp_station)
+
+        normalized = self.normalize(location)
+        if not normalized:
+            return None
+
+        matches = await self.firebird.find_station_by_name(normalized)
+        if len(matches) == 1:
+            return int(matches[0][0])
+        if len(matches) == 0:
+            self.logger.warning(f"Не найдено станции для '{location}'")
+        else:
+            self.logger.warning(
+                f"Найдено несколько станций для '{location}': {[m[0] for m in matches]}"
+            )
+        return None
+
+    async def update_entity(self, entity_id: int, location: str, sp_station: Optional[str] = None) -> bool:
+        station_id = await self.resolve_station_id(location, sp_station)
+        if station_id is None:
+            return False
+
+        current_id = await self.firebird.get_entity_station_id(entity_id)
+        if current_id == station_id:
+            return False
+
+        success = await self.firebird.update_entity_station_id(entity_id, station_id)
+        if success:
+            self.logger.info(
+                f"ENTITY {entity_id}: station {current_id} -> {station_id}"
+            )
+        return success
+
+    async def process_records(self, records: List[Dict[str, Any]]) -> Dict[str, int]:
+        """Process a batch of cache records."""
+        stats = {"updated": 0, "skipped": 0, "conflict": 0}
+        for rec in records:
+            entity_id = rec.get("entity_id")
+            location = rec.get("location", "")
+            sp_station = rec.get("sp_station")
+            updated = await self.update_entity(entity_id, location, sp_station)
+            if updated:
+                stats["updated"] += 1
+            else:
+                stats["skipped"] += 1
+        return stats

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -207,7 +207,7 @@ async def test_update_remaining_distance_when_date_skipped():
 
     await engine.run_full_workflow(batch_size=10)
 
-    assert firebird.updated == [20]
+    assert firebird.updated == [(20, '500')]
 
 @pytest.mark.asyncio
 async def test_skip_container_with_no_order():

--- a/tests/processing/test_google_sheets_sync.py
+++ b/tests/processing/test_google_sheets_sync.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from processing.google_sheets_sync import GoogleSheetsSync, SheetRow, SheetInterface
+
+
+class SimpleSheet(SheetInterface):
+    def __init__(self):
+        self.rows = {}
+
+    def get(self, container: str):
+        return self.rows.get(container)
+
+    def update(self, container: str, data):
+        self.rows[container] = data
+
+    def add(self, data):
+        self.rows[data["Контейнер"]] = data
+
+
+class DummyFirebird:
+    async def get_station_name_by_id(self, station_id):
+        return {4451: "Москва-Каланчёвская"}.get(station_id)
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_distance_and_date():
+    sheet = SimpleSheet()
+    fb = DummyFirebird()
+    sync = GoogleSheetsSync(sheet, fb)
+
+    row = SheetRow(
+        container="MSCU1234567",
+        railway_loading="2025-09-01",
+        distance=225.0,
+        station_id=4451,
+    )
+    await sync.upsert_row(row)
+    saved = sheet.get("MSCU1234567")
+    assert saved["Станция местоположения"] == "Москва-Каланчёвская"
+    first_date = saved["Дата обновления слежения"]
+
+    row2 = SheetRow(
+        container="MSCU1234567",
+        railway_loading="2025-09-01",
+        distance=225.0,
+        station_id=4451,
+    )
+    await sync.upsert_row(row2)
+    saved = sheet.get("MSCU1234567")
+    assert saved["Дата обновления слежения"] == first_date
+
+    row3 = SheetRow(
+        container="MSCU1234567",
+        railway_loading="2025-09-01",
+        distance=218.0,
+        station_id=4451,
+    )
+    await sync.upsert_row(row3)
+    saved = sheet.get("MSCU1234567")
+    assert saved["Дата обновления слежения"] == sync._today_str()
+    assert saved["Операция"] == "В пути"

--- a/tests/processing/test_station_updater.py
+++ b/tests/processing/test_station_updater.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+from processing.station_updater import StationUpdater
+
+
+class DummyFirebird:
+    def __init__(self):
+        self.stations = {"МОСКВА": [(4451, "Москва-Каланчёвская")]}
+        self.entities = {}
+
+    async def find_station_by_name(self, name):
+        return self.stations.get(name, [])
+
+    async def get_entity_station_id(self, entity_id):
+        return self.entities.get(entity_id)
+
+    async def update_entity_station_id(self, entity_id, station_id):
+        self.entities[entity_id] = station_id
+        return True
+
+
+@pytest.mark.asyncio
+async def test_station_updater_updates_only_changed():
+    fb = DummyFirebird()
+    updater = StationUpdater(fb)
+    records = [{"entity_id": 1, "location": " ст. Москва "}]
+    stats = await updater.process_records(records)
+    assert fb.entities[1] == 4451
+    assert stats["updated"] == 1
+
+    # повторная обработка не должна обновлять
+    stats = await updater.process_records(records)
+    assert stats["skipped"] == 1
+
+
+def test_normalize_removes_prefixes():
+    assert StationUpdater.normalize(" ст. Владивосток ") == "ВЛАДИВОСТОК"

--- a/utils/db/firebird_manager.py
+++ b/utils/db/firebird_manager.py
@@ -82,11 +82,6 @@ class EntityStatusID(IntEnum):
     TERMINAL_OPERATION_AUTO = 57 # "ТО (прямое авто)"
     FTL_RELEASE = 58 # "04...Выпуск FTL"
 
-    
-    class ENTITY_CURRENT_STATION_ID(IntEnum):
-        
-
-
     @classmethod
     def get_excluded_statuses(cls) -> Set[int]:
         """Статусы, которые исключаем из обработки"""
@@ -1111,6 +1106,120 @@ class FirebirdEntityManager:
         except Exception as e:
             self.logger.error(f"❌ Ошибка обновления ID {entity_id}: {e}")
             return False
+
+    # ---------------------------------------------------------------------
+    #  Дополнительные методы для работы со станциями
+    # ---------------------------------------------------------------------
+
+    def _sync_get_entity_station_id(self, entity_id: int) -> Optional[int]:
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                f"""
+                SELECT {self.entity_config.railway_current_station}
+                FROM {self.entity_config.table_name}
+                WHERE {self.entity_config.primary_key} = ?
+                """,
+                [entity_id],
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+    async def get_entity_station_id(self, entity_id: int) -> Optional[int]:
+        """Получить текущий station_id для entity"""
+
+        def _fetch():
+            return self._sync_get_entity_station_id(entity_id)
+
+        try:
+            async with self._get_thread_pool() as pool:
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(pool, _fetch)
+        except Exception as e:
+            self.logger.error(f"❌ Ошибка получения station_id для ID {entity_id}: {e}")
+            return None
+
+    def _sync_update_station_id(self, entity_id: int, station_id: int) -> bool:
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                f"""
+                UPDATE {self.entity_config.table_name}
+                SET {self.entity_config.railway_current_station} = ?
+                WHERE {self.entity_config.primary_key} = ?
+                """,
+                [station_id, entity_id],
+            )
+            connection.commit()
+            return cursor.rowcount > 0
+
+    async def update_entity_station_id(self, entity_id: int, station_id: int) -> bool:
+        """Обновить station_id для entity"""
+
+        def _update():
+            return self._sync_update_station_id(entity_id, station_id)
+
+        try:
+            async with self._get_thread_pool() as pool:
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(pool, _update)
+        except Exception as e:
+            self.logger.error(f"❌ Ошибка обновления station_id для ID {entity_id}: {e}")
+            return False
+
+    def _sync_find_station_by_name(self, name: str) -> List[Tuple[int, str]]:
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                """
+                SELECT ID, NAME FROM SP_RAILWAY_STATION
+                WHERE UPPER(NAME) = ?
+                   OR UPPER(ALIAS) = ?
+                   OR UPPER(SHORT_NAME) = ?
+                """,
+                [name, name, name],
+            )
+            return cursor.fetchall()
+
+    async def find_station_by_name(self, name: str) -> List[Tuple[int, str]]:
+        """Найти станции по нормализованному названию"""
+
+        norm = name.upper().strip()
+
+        def _fetch():
+            return self._sync_find_station_by_name(norm)
+
+        try:
+            async with self._get_thread_pool() as pool:
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(pool, _fetch)
+        except Exception as e:
+            self.logger.error(f"❌ Ошибка поиска станции по имени {name}: {e}")
+            return []
+
+    def _sync_get_station_name(self, station_id: int) -> Optional[str]:
+        with self.connection_manager.get_connection() as connection:
+            cursor = connection.cursor()
+            cursor.execute(
+                "SELECT NAME FROM SP_RAILWAY_STATION WHERE ID = ?",
+                [station_id],
+            )
+            row = cursor.fetchone()
+            return row[0] if row else None
+
+    async def get_station_name_by_id(self, station_id: int) -> Optional[str]:
+        """Получить название станции по ID"""
+
+        def _fetch():
+            return self._sync_get_station_name(station_id)
+
+        try:
+            async with self._get_thread_pool() as pool:
+                loop = asyncio.get_event_loop()
+                return await loop.run_in_executor(pool, _fetch)
+        except Exception as e:
+            self.logger.error(f"❌ Ошибка получения названия станции {station_id}: {e}")
+            return None
     
     # =========================================================================
     # УТИЛИТЫ И СТАТИСТИКА


### PR DESCRIPTION
## Summary
- add utility to normalize locations and update station IDs in Firebird
- implement Google Sheets synchronization with distance and operation rules
- expose Firebird helpers for station lookup and updating current station
- fix event merging to prefer smaller remaining distance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be362d89f8832aa619e302291668c2