### PR TITLE
Fix gspread row append behavior

### DIFF
--- a/processing/google_sheets_sync.py
+++ b/processing/google_sheets_sync.py
@@ -79,7 +79,13 @@ class WorksheetAdapter:
         return dict(zip(headers, values))
 
     def append_row(self, row: SheetRow) -> None:
-        if hasattr(self.worksheet, "append_row"):
+        """Append *row* to the worksheet.
+
+        Fake worksheets used in tests implement ``update_row`` and expect the
+        :class:`SheetRow` instance directly. Real gspread worksheets do not have
+        ``update_row``; they require a list of values and a ``value_input_option``.
+        """
+        if hasattr(self.worksheet, "update_row"):
             self.worksheet.append_row(row)
         else:  # pragma: no cover - real gspread
             self.worksheet.append_row(row.to_list(), value_input_option="USER_ENTERED")

--- a/tests/processing/test_google_sheets_sync.py
+++ b/tests/processing/test_google_sheets_sync.py
@@ -32,6 +32,18 @@ class FakeWorksheet:
         self.rows[index] = row
 
 
+class StubGspreadWorksheet:
+    """Mimics the minimal gspread interface used by :class:`WorksheetAdapter`."""
+
+    def __init__(self):
+        self.args = None
+        self.kwargs = None
+
+    def append_row(self, *args, **kwargs):  # pragma: no cover - exercised via adapter
+        self.args = args
+        self.kwargs = kwargs
+
+
 def test_map_operation_rules():
     assert GoogleSheetsSync.map_operation(None, 10, False, 0) == "В пути"
     assert GoogleSheetsSync.map_operation("прибыл на станцию назначения", 0, True) == "прибыл на станцию назначения"
@@ -65,3 +77,14 @@ def test_upsert_updates_tracking_date_only_on_distance_change():
     sync.sync_row(data)
     assert sheet.worksheet.rows[0].tracking_date == "09-09-2025"
     assert sheet.worksheet.rows[0].distance == 218.0
+
+
+def test_adapter_converts_row_for_gspread():
+    stub = StubGspreadWorksheet()
+    adapter = WorksheetAdapter(stub)
+    row = SheetRow("C1", "01-01-2024", "02-01-2024", "В пути", 1.0, "Москва")
+
+    adapter.append_row(row)
+
+    assert stub.args[0] == row.to_list()
+    assert stub.kwargs.get("value_input_option") == "USER_ENTERED"


### PR DESCRIPTION
## Summary
- ensure WorksheetAdapter converts SheetRow to list when using gspread
- add regression test for gspread-style append_row expectations

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: test_update_remaining_distance_when_date_skipped, test_merge_prefers_smaller_remaining_distance)*

------
https://chatgpt.com/codex/tasks/task_e_68be66a2bf04832a9d77c74e1f7f85a6