### PR TITLE
Add final Google Sheets synchronization routine

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -552,7 +552,11 @@ class ContainerTrackingEngine:
                     )
                 except Exception:
                     distance_val = 0.0
-                at_destination = bool(existing.get("at_destination", False))
+                at_destination_raw = existing.get("at_destination")
+                if at_destination_raw in (None, ""):
+                    at_destination = distance_val == 0
+                else:
+                    at_destination = bool(at_destination_raw)
             else:
                 distance_val = distance
                 at_destination = distance == 0

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -264,6 +264,44 @@ async def test_missing_distance_keeps_existing_sheet_status():
     assert data["Расстояние до станции назначения"] == 123
     assert data["at_destination"] is False
 
+
+@pytest.mark.asyncio
+async def test_infer_destination_when_flag_missing():
+    containers = [
+        ContainerInfo(id=1, container_number="CONT1", line_id=1, current_dates={}),
+    ]
+    firebird = DummyFirebirdManager(containers)
+    cache = DummyCache()
+    config = Config(database=FirebirdDatabaseConfig(database="test.fdb", password="pass"))
+    google_sync = DummyGoogleSync([c.container_number for c in containers])
+    # Prepopulate sheet with arrived distance but without at_destination flag
+    google_sync.ws.rows[0]["Расстояние до станции назначения"] = 0
+    engine = ContainerTrackingEngine(config, cache, firebird, google_sync=google_sync)
+
+    order_map = {c.container_number: "ORD1" for c in containers}
+    engine.api_client.find_order_by_container = AsyncMock(side_effect=lambda s, cn: order_map[cn])
+    engine.api_client.get_order_tracking = AsyncMock(return_value={"data": []})
+    engine._data_unchanged = lambda cached, current: False
+
+    async def dummy_process_single_container(self, session, container, order_id, order_data):
+        res = TrackingResult(container_number=container.container_number)
+        res.order_id = order_id
+        res.last_event = ContainerEvent(
+            date="2024-01-01", operation="Load", location="Test", remainingDistance=None
+        )
+        return res
+
+    engine._process_single_container = types.MethodType(dummy_process_single_container, engine)
+
+    await engine.run_full_workflow(batch_size=10)
+
+    assert google_sync.sync_row.call_count == 1
+    args, _ = google_sync.sync_row.call_args
+    data = args[0]
+    assert data["Расстояние до станции назначения"] == 0
+    assert data["at_destination"] is True
+
+
 @pytest.mark.asyncio
 async def test_update_remaining_distance_when_date_skipped():
     container = ContainerInfo(


### PR DESCRIPTION
## Summary
- add `WorksheetAdapter.list_containers` for column retrieval
- implement deferred Google Sheet synchronization in `ContainerTrackingEngine`
- update tests with dummy Google sync adapter and ensure final sync invoked
- ensure event merging keeps smallest remaining distance
- preserve existing sheet distance/status when remaining distance is missing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c79ae958c4832a810c36df360b0457