### PR TITLE
Make Google Sheets sync asynchronous

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -521,7 +521,7 @@ class ContainerTrackingEngine:
                         else None,
                     }
                     try:
-                        self.google_sync.sync_row(row_data)
+                        await self.google_sync.sync_row(row_data)
                     except Exception as gs_err:
                         self.logger.error(
                             f"❌ Ошибка синхронизации Google Sheets для {container_info.container_number}: {gs_err}"
@@ -593,7 +593,7 @@ class ContainerTrackingEngine:
                 "Станция местоположения": container_data.get("location", ""),
             }
             try:
-                self.google_sync.sync_row(data)
+                await self.google_sync.sync_row(data)
             except Exception as e:
                 self.logger.error(
                     f"❌ Ошибка синхронизации контейнера {container}: {e}"

--- a/processing/google_sheets_sync.py
+++ b/processing/google_sheets_sync.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Optional, Callable
 from zoneinfo import ZoneInfo
+import asyncio
 import os
 
 from utils.logging import get_logger
@@ -209,7 +210,13 @@ class GoogleSheetsSync:
         return "В пути"
 
     # ------------------------------------------------------------------
-    def sync_row(self, data: Dict[str, object], stagnant_days: int = 0) -> bool:
+    async def sync_row(self, data: Dict[str, object], stagnant_days: int = 0) -> bool:
+        """Asynchronously upsert a single row in the worksheet."""
+
+        return await asyncio.to_thread(self._sync_row, data, stagnant_days)
+
+    # ------------------------------------------------------------------
+    def _sync_row(self, data: Dict[str, object], stagnant_days: int = 0) -> bool:
         """Upsert a single row in the worksheet.
 
         Parameters
@@ -237,7 +244,9 @@ class GoogleSheetsSync:
         today = self.now_func().strftime("%d-%m-%Y")
 
         if existing_index is None:
-            row = SheetRow(container, loading_date, today, operation, distance, station_name)
+            row = SheetRow(
+                container, loading_date, today, operation, distance, station_name
+            )
             self.ws.append_row(row)
             self.logger.info("Row added for %s", container)
             return True

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -113,8 +113,9 @@ class DummyGoogleSync:
         self.ws = DummyWorksheet(containers) if containers is not None else None
         self.calls = []
 
-    def sync_row(self, data, stagnant_days: int = 0):
+    async def sync_row(self, data, stagnant_days: int = 0):
         self.calls.append((data, stagnant_days))
+        return True
 
 
 @pytest.mark.asyncio

--- a/tests/processing/test_google_sheets_sync.py
+++ b/tests/processing/test_google_sheets_sync.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+import pytest
+
 from processing.google_sheets_sync import (
     WorksheetAdapter,
     GoogleSheetsSync,
@@ -65,7 +67,8 @@ def test_map_operation_rules():
     assert GoogleSheetsSync.map_operation("Отгружен", 5, False, 0) == "Отгружен"
 
 
-def test_upsert_updates_tracking_date_only_on_distance_change():
+@pytest.mark.asyncio
+async def test_upsert_updates_tracking_date_only_on_distance_change():
     sheet = WorksheetAdapter(FakeWorksheet())
     fixed_now = lambda: datetime(2025, 9, 8, 10, 0, 0)
     sync = GoogleSheetsSync(sheet, now_func=fixed_now)
@@ -77,20 +80,20 @@ def test_upsert_updates_tracking_date_only_on_distance_change():
         "Станция местоположения": "Москва",
         "Операция": "В пути",
     }
-    sync.sync_row(data)
+    await sync.sync_row(data)
     assert len(sheet.worksheet.rows) == 1
     first_date = sheet.worksheet.rows[0].tracking_date
     assert sheet.worksheet.rows[0].operation == "Отгружен"
 
     # Second call with same distance -> date not changed
-    sync.sync_row(data)
+    await sync.sync_row(data)
     assert sheet.worksheet.rows[0].tracking_date == first_date
     assert sheet.worksheet.rows[0].operation == "В пути"
 
     # Third call with changed distance -> date updated
     sync.now_func = lambda: datetime(2025, 9, 9, 10, 0, 0)
     data["Расстояние до станции назначения"] = 218.0
-    sync.sync_row(data)
+    await sync.sync_row(data)
     assert sheet.worksheet.rows[0].tracking_date == "09-09-2025"
     assert sheet.worksheet.rows[0].distance == 218.0
     assert sheet.worksheet.rows[0].operation == "В пути"


### PR DESCRIPTION
## Summary
- convert `GoogleSheetsSync.sync_row` into an async helper backed by `asyncio.to_thread`
- await Google Sheet synchronisation inside the engine when writing results and refreshing from cache
- update unit tests to work with the asynchronous sheet API

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8b3032fe8832ab573d82654ea63da