### PR TITLE
Skip Google Sheets sync when row missing

### DIFF
--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -560,11 +560,9 @@ class ContainerTrackingEngine:
             if not container_data:
                 continue
             row_idx = self.google_sync.ws.find_row(container)
-            existing = (
-                self.google_sync.ws.get_row(row_idx)
-                if row_idx is not None
-                else {}
-            )
+            if row_idx is None:
+                continue
+            existing = self.google_sync.ws.get_row(row_idx) or {}
             rem_raw = container_data.get("remainingDistance")
             distance: Optional[float] = None
             if rem_raw not in (None, ""):


### PR DESCRIPTION
## Summary
- stop syncing cached Google Sheets rows when the corresponding sheet row cannot be found

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8ce751d20832aa1ecd94725259faa