### PR TITLE
Add service account authentication for Google Sheets sync

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -257,6 +257,10 @@ class GoogleSheetsConfig:
     token_file: str = "token.json"
     timezone: str = "Asia/Vladivostok"
     batch_size: int = 20
+    service_account_file: str = ""
+    service_account_info: Optional[Union[str, Dict[str, Any]]] = None
+    delegated_subject: Optional[str] = None
+    scopes: Optional[List[str]] = None
 
     def __post_init__(self):
         if not isinstance(self.sheet_id, str):
@@ -265,6 +269,22 @@ class GoogleSheetsConfig:
             raise ConfigError("worksheet должен быть строкой")
         if self.batch_size <= 0:
             raise ConfigError("batch_size должен быть положительным")
+        self.client_secret_file = self.client_secret_file.strip()
+        self.service_account_file = self.service_account_file.strip()
+        if isinstance(self.service_account_info, str):
+            info = self.service_account_info.strip()
+            self.service_account_info = info if info else None
+        elif self.service_account_info is not None and not isinstance(self.service_account_info, dict):
+            raise ConfigError(
+                "service_account_info должен быть строкой или словарем с учетными данными"
+            )
+        if self.delegated_subject is not None:
+            if not isinstance(self.delegated_subject, str):
+                raise ConfigError("delegated_subject должен быть строкой")
+            self.delegated_subject = self.delegated_subject.strip() or None
+        if self.scopes is not None:
+            if not isinstance(self.scopes, list) or not all(isinstance(scope, str) for scope in self.scopes):
+                raise ConfigError("scopes должен быть списком строк")
 
 
 @dataclass
@@ -560,10 +580,14 @@ class Config:
         
         if "database" in result and isinstance(result["database"], dict):
             result["database"]["password"] = "***"
-        
+
         if "external_database" in result and isinstance(result["external_database"], dict):
             result["external_database"]["password"] = "***"
-            
+
+        google_cfg = result.get("google_sheets")
+        if isinstance(google_cfg, dict) and google_cfg.get("service_account_info"):
+            google_cfg["service_account_info"] = "***"
+
         return result
 
 

--- a/processing/ContainerTrackingEngine.py
+++ b/processing/ContainerTrackingEngine.py
@@ -819,7 +819,17 @@ async def create_container_tracking_engine(
     if gs_cfg is not None:
         sheet_id = getattr(gs_cfg, "sheet_id", "").strip()
         client_secret = getattr(gs_cfg, "client_secret_file", "").strip()
-        if sheet_id and client_secret:
+        service_account_file = getattr(gs_cfg, "service_account_file", "")
+        if isinstance(service_account_file, str):
+            service_account_file = service_account_file.strip()
+        service_account_info = getattr(gs_cfg, "service_account_info", None)
+        if isinstance(service_account_info, str):
+            service_account_info = service_account_info.strip() or None
+        has_service_account = bool(service_account_file) or service_account_info is not None
+        has_oauth = bool(client_secret)
+        has_credentials = has_oauth or has_service_account
+
+        if sheet_id and has_credentials:
             logger.info(
                 "📝 Настройка интеграции с Google Sheets для листа %s", gs_cfg.worksheet
             )
@@ -834,9 +844,13 @@ async def create_container_tracking_engine(
                 logger.error(
                     "⚠️ Не удалось инициализировать Google Sheets: %s", exc
                 )
-        elif sheet_id or client_secret:
+        elif sheet_id and not has_credentials:
             logger.warning(
-                "⚠️ Google Sheets конфигурация неполная — интеграция отключена"
+                "⚠️ Google Sheets конфигурация неполная — отсутствуют учетные данные"
+            )
+        elif has_credentials and not sheet_id:
+            logger.warning(
+                "⚠️ Google Sheets конфигурация неполная — не указан sheet_id"
             )
 
     # Создаем engine

--- a/processing/google_sheets_sync.py
+++ b/processing/google_sheets_sync.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, Optional, Callable, Iterable, List
+from typing import Any, Dict, Optional, Callable, Iterable, List
 from zoneinfo import ZoneInfo
 import asyncio
+import json
 import os
 
 from utils.logging import get_logger
@@ -20,11 +21,12 @@ from config.settings import GoogleSheetsConfig
 try:  # pragma: no cover - optional dependency for real usage
     import gspread  # type: ignore
     from google.auth.transport.requests import Request  # type: ignore
+    from google.oauth2 import service_account  # type: ignore
     from google.oauth2.credentials import Credentials  # type: ignore
     from google_auth_oauthlib.flow import InstalledAppFlow  # type: ignore
 except Exception:  # pragma: no cover
     gspread = None  # type: ignore
-    Request = Credentials = InstalledAppFlow = None  # type: ignore
+    Request = Credentials = InstalledAppFlow = service_account = None  # type: ignore
 
 logger = get_logger("google_sheets_sync")
 
@@ -151,14 +153,19 @@ SCOPES = [
 def get_authenticated_worksheet(
     sheet_id: str,
     worksheet_name: str,
-    client_secret_file: str,
+    client_secret_file: str = "",
     token_file: str = "token.json",
+    service_account_file: Optional[str] = None,
+    service_account_info: Optional[Dict[str, Any] | str] = None,
+    subject: Optional[str] = None,
+    scopes: Optional[List[str]] = None,
 ) -> WorksheetAdapter:
     """Return an authenticated :class:`WorksheetAdapter` for Google Sheets.
 
-    The function performs the OAuth flow using the provided ``client_secret``
-    file generated in Google Cloud.  Credentials are cached in ``token_file``
-    so the interactive flow is required only once.
+    The helper supports both the traditional OAuth flow (using ``client_secret``
+    files) and service account credentials.  When a service account file or
+    JSON payload is provided the OAuth flow is skipped entirely, allowing the
+    application to run in headless environments without user interaction.
 
     Parameters
     ----------
@@ -168,26 +175,102 @@ def get_authenticated_worksheet(
         Name of the worksheet within the document.
     client_secret_file:
         Path to the OAuth 2.0 Client ID JSON file downloaded from Google Cloud.
+        Used when service account credentials are not supplied.
     token_file:
-        Location where the access/refresh token pair will be stored.  Defaults
-        to ``token.json`` in the current directory.
+        Location where the access/refresh token pair will be stored for OAuth.
+    service_account_file:
+        Optional path to the service account JSON key.
+    service_account_info:
+        Optional JSON payload (``dict`` or JSON string) with service account
+        credentials.  This is useful when credentials are provided via
+        environment variables or secret stores.
+    subject:
+        Optional subject for domain-wide delegation.
+    scopes:
+        Optional list of scopes to request.  Defaults to :data:`SCOPES` when
+        ``None``.
     """
 
-    if gspread is None or Credentials is None:
-        raise ImportError("gspread and google-auth libraries are required for OAuth")
+    if gspread is None:
+        raise ImportError("gspread and google-auth libraries are required")
 
-    creds: Optional[Credentials] = None
-    if os.path.exists(token_file):
-        creds = Credentials.from_authorized_user_file(token_file, SCOPES)
+    scopes_to_use = SCOPES if scopes is None else scopes
 
-    if not creds or not creds.valid:
-        if creds and creds.expired and creds.refresh_token:
-            creds.refresh(Request())
+    creds: Any
+    # ------------------------------------------------------------------
+    # Service account authentication (preferred when available)
+    if (service_account_file and service_account_file.strip()) or service_account_info:
+        if service_account is None:
+            raise ImportError(
+                "google.oauth2.service_account is required for service account authentication"
+            )
+
+        info_payload: Optional[Dict[str, Any]] = None
+        if service_account_info is not None:
+            if isinstance(service_account_info, dict):
+                info_payload = service_account_info
+            elif isinstance(service_account_info, str):
+                candidate = service_account_info.strip()
+                if candidate:
+                    if os.path.exists(candidate):
+                        with open(candidate, "r", encoding="utf-8") as fp:
+                            info_payload = json.load(fp)
+                    else:
+                        try:
+                            info_payload = json.loads(candidate)
+                        except json.JSONDecodeError as exc:
+                            raise ValueError(
+                                "service_account_info must be a JSON string, dict or path to a JSON file"
+                            ) from exc
+            else:
+                raise TypeError(
+                    "service_account_info must be either a dict, JSON string or path to a JSON file"
+                )
+
+        if info_payload is not None:
+            creds = service_account.Credentials.from_service_account_info(
+                info_payload, scopes=scopes_to_use
+            )
+        elif service_account_file and service_account_file.strip():
+            creds = service_account.Credentials.from_service_account_file(
+                service_account_file, scopes=scopes_to_use
+            )
         else:
-            flow = InstalledAppFlow.from_client_secrets_file(client_secret_file, SCOPES)
-            creds = flow.run_local_server(port=0)
-        with open(token_file, "w", encoding="utf-8") as token:
-            token.write(creds.to_json())
+            raise ValueError(
+                "Service account configuration requires either service_account_file or service_account_info"
+            )
+
+        if subject:
+            creds = creds.with_subject(subject)
+
+    # ------------------------------------------------------------------
+    # OAuth authentication (interactive, cached locally)
+    else:
+        if Credentials is None or Request is None or InstalledAppFlow is None:
+            raise ImportError(
+                "google-auth oauth client libraries are required for interactive authentication"
+            )
+        if not client_secret_file:
+            raise ValueError(
+                "client_secret_file must be provided when service account credentials are not supplied"
+            )
+
+        oauth_creds: Optional[Credentials] = None
+        if os.path.exists(token_file):
+            oauth_creds = Credentials.from_authorized_user_file(token_file, scopes_to_use)
+
+        if not oauth_creds or not oauth_creds.valid:
+            if oauth_creds and oauth_creds.expired and oauth_creds.refresh_token:
+                oauth_creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    client_secret_file, scopes_to_use
+                )
+                oauth_creds = flow.run_local_server(port=0)
+            with open(token_file, "w", encoding="utf-8") as token:
+                token.write(oauth_creds.to_json())
+
+        creds = oauth_creds
 
     client = gspread.authorize(creds)
     worksheet = client.open_by_key(sheet_id).worksheet(worksheet_name)
@@ -339,8 +422,19 @@ class GoogleSheetsSync:
 def create_sync_from_config(cfg: GoogleSheetsConfig) -> GoogleSheetsSync:
     """Utility to build :class:`GoogleSheetsSync` from config."""
 
+    info = getattr(cfg, "service_account_info", None)
+    if isinstance(info, str) and not info.strip():
+        info = None
+
     worksheet = get_authenticated_worksheet(
-        cfg.sheet_id, cfg.worksheet, cfg.client_secret_file, cfg.token_file
+        cfg.sheet_id,
+        cfg.worksheet,
+        client_secret_file=getattr(cfg, "client_secret_file", ""),
+        token_file=getattr(cfg, "token_file", "token.json"),
+        service_account_file=(getattr(cfg, "service_account_file", "") or None),
+        service_account_info=info,
+        subject=getattr(cfg, "delegated_subject", None),
+        scopes=getattr(cfg, "scopes", None),
     )
     return GoogleSheetsSync(
         worksheet,

--- a/tests/processing/test_engine.py
+++ b/tests/processing/test_engine.py
@@ -167,6 +167,33 @@ async def test_factory_initialises_google_sheets_sync(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_factory_initialises_google_sheets_with_service_account(monkeypatch):
+    cache = DummyCache()
+    config = Config(
+        database=FirebirdDatabaseConfig(database="test.fdb", password="pass"),
+        google_sheets=GoogleSheetsConfig(
+            sheet_id="sheet-123",
+            worksheet="Лист1",
+            service_account_file="/tmp/service.json",
+        ),
+    )
+
+    manager = DummyFirebirdManager([])
+    module = sys.modules["processing.ContainerTrackingEngine"]
+    monkeypatch.setattr(module, "create_firebird_entity_manager", lambda **_: manager)
+
+    def fake_create_sync(cfg):
+        assert cfg is config.google_sheets
+        return DummyGoogleSync(containers=["C2"])
+
+    monkeypatch.setattr(module, "create_sync_from_config", fake_create_sync)
+
+    engine = await create_container_tracking_engine(config, cache)
+    assert isinstance(engine.google_sync, DummyGoogleSync)
+    assert engine.google_sync.ws is not None
+
+
+@pytest.mark.asyncio
 async def test_factory_recovers_from_google_sheets_errors(monkeypatch):
     cache = DummyCache()
     config = Config(

--- a/tests/processing/test_google_sheets_sync.py
+++ b/tests/processing/test_google_sheets_sync.py
@@ -1,6 +1,9 @@
+import json
 import os
 import sys
 from datetime import datetime
+from types import SimpleNamespace
+from typing import Optional
 
 import pytest
 
@@ -13,6 +16,7 @@ from processing.google_sheets_sync import (
     SheetRow,
     create_sync_from_config,
 )
+import processing.google_sheets_sync as gs_sync
 from config.settings import GoogleSheetsConfig
 
 
@@ -163,11 +167,24 @@ def test_create_sync_from_config(monkeypatch):
     )
     fake_ws = WorksheetAdapter(FakeWorksheet())
 
-    def fake_auth(sheet_id, worksheet_name, client_secret_file, token_file="token.json"):
+    def fake_auth(
+        sheet_id,
+        worksheet_name,
+        client_secret_file="",
+        token_file="token.json",
+        service_account_file=None,
+        service_account_info=None,
+        subject=None,
+        scopes=None,
+    ):
         assert sheet_id == "ID1"
         assert worksheet_name == "Лист1"
         assert client_secret_file == "secret.json"
         assert token_file == "token.json"
+        assert service_account_file in (None, "")
+        assert service_account_info is None
+        assert subject is None
+        assert scopes is None
         return fake_ws
 
     monkeypatch.setattr(
@@ -176,6 +193,86 @@ def test_create_sync_from_config(monkeypatch):
     sync = create_sync_from_config(cfg)
     assert isinstance(sync, GoogleSheetsSync)
     assert sync.ws is fake_ws
+
+
+def test_get_authenticated_worksheet_with_service_account(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class DummyCreds:
+        def __init__(self, source: str):
+            self.source = source
+            self.subject: Optional[str] = None
+
+        def with_subject(self, subject: str):
+            self.subject = subject
+            return self
+
+    class DummyCredentialsFactory:
+        @staticmethod
+        def from_service_account_file(filename, scopes=None):
+            captured["file"] = filename
+            captured["scopes"] = scopes
+            return DummyCreds("file")
+
+        @staticmethod
+        def from_service_account_info(info, scopes=None):
+            captured["info"] = info
+            captured["scopes"] = scopes
+            return DummyCreds("info")
+
+    class DummyServiceAccountModule:
+        Credentials = DummyCredentialsFactory
+
+    class DummySpreadsheet:
+        def worksheet(self, name):
+            captured["worksheet_name"] = name
+            return SimpleNamespace(name=name)
+
+    class DummyClient:
+        def __init__(self):
+            self.sheet = DummySpreadsheet()
+
+        def open_by_key(self, key):
+            captured["sheet_id"] = key
+            return self.sheet
+
+    def fake_authorize(creds):
+        captured["authorized_creds"] = creds
+        return DummyClient()
+
+    monkeypatch.setattr(gs_sync, "service_account", DummyServiceAccountModule)
+    monkeypatch.setattr(gs_sync, "gspread", SimpleNamespace(authorize=fake_authorize))
+
+    adapter = gs_sync.get_authenticated_worksheet(
+        "sheet-1",
+        "Лист1",
+        service_account_file="/path/key.json",
+        subject="user@example.com",
+    )
+
+    assert isinstance(adapter, WorksheetAdapter)
+    assert captured["file"] == "/path/key.json"
+    assert captured["sheet_id"] == "sheet-1"
+    assert captured["worksheet_name"] == "Лист1"
+    assert captured["authorized_creds"].source == "file"
+    assert captured["authorized_creds"].subject == "user@example.com"
+    assert captured["scopes"] == gs_sync.SCOPES
+
+    info_payload = {"type": "service_account", "client_email": "robot@example.com"}
+    adapter = gs_sync.get_authenticated_worksheet(
+        "sheet-2",
+        "Лист2",
+        service_account_info=json.dumps(info_payload),
+        scopes=["scope1"],
+    )
+
+    assert isinstance(adapter, WorksheetAdapter)
+    assert captured["info"] == info_payload
+    assert captured["sheet_id"] == "sheet-2"
+    assert captured["worksheet_name"] == "Лист2"
+    assert captured["authorized_creds"].source == "info"
+    assert captured["authorized_creds"].subject is None
+    assert captured["scopes"] == ["scope1"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add optional service account authentication support to the Google Sheets sync helper and factory
- extend configuration to capture service account credentials and hide secrets in diagnostic dumps
- adjust engine bootstrap and tests to cover both OAuth and service account credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca4de94498832a9e32e1f96d4970af